### PR TITLE
Fix error when response has no content-type

### DIFF
--- a/drf_api_logger/middleware/api_logger_middleware.py
+++ b/drf_api_logger/middleware/api_logger_middleware.py
@@ -81,7 +81,7 @@ class APILoggerMiddleware:
 
             headers = get_headers(request=request)
             method = request.method
-            if response['content-type'] == 'application/json':
+            if 'content-type' in response and response['content-type'] == 'application/json':
                 if getattr(response, 'streaming', False):
                     response_body = '** Streaming **'
                 else:


### PR DESCRIPTION
When the response didn't contain a content-type header (e.g. an empty
HTTP 204 response), APILoggerMiddleware threw a KeyError exception.