### PR TITLE
Added support for logging APIs returning GZIP data

### DIFF
--- a/drf_api_logger/middleware/api_logger_middleware.py
+++ b/drf_api_logger/middleware/api_logger_middleware.py
@@ -101,8 +101,11 @@ class APILoggerMiddleware:
             if len(self.DRF_API_LOGGER_METHODS) > 0 and method not in self.DRF_API_LOGGER_METHODS:
                 return response
 
-            if response.get('content-type') in ('application/json', 'application/vnd.api+json',):
-                if getattr(response, 'streaming', False):
+            if response.get('content-type') in ('application/json', 'application/vnd.api+json', 'application/gzip'):
+                
+                if response.get('content-type') == 'application/gzip':
+                    response_body = '** GZIP Archive **'
+                elif getattr(response, 'streaming', False):
                     response_body = '** Streaming **'
                 else:
                     if type(response.content) == bytes:


### PR DESCRIPTION
This change allows the API Logger to capture a log message for API calls in which the response includes content of type "application/gzip". Since the the binary archive should not be included in the log file, the response_body merely indicates the content type.

Prior to this change, API requests returning GZIP data were simply not logged.  