### PR TITLE
Added logic to exclude parameters present in the APU URL string

### DIFF
--- a/drf_api_logger/middleware/api_logger_middleware.py
+++ b/drf_api_logger/middleware/api_logger_middleware.py
@@ -1,5 +1,6 @@
 import json
 import time
+import re
 from django.conf import settings
 from django.urls import resolve
 from django.utils import timezone
@@ -122,7 +123,7 @@ class APILoggerMiddleware:
                     api = request.build_absolute_uri()
 
                 data = dict(
-                    api=api,
+                    api=mask_sensitive_data(api, mask_api_parameters=True),
                     headers=mask_sensitive_data(headers),
                     body=mask_sensitive_data(request_data),
                     method=method,

--- a/drf_api_logger/middleware/api_logger_middleware.py
+++ b/drf_api_logger/middleware/api_logger_middleware.py
@@ -101,8 +101,11 @@ class APILoggerMiddleware:
             if len(self.DRF_API_LOGGER_METHODS) > 0 and method not in self.DRF_API_LOGGER_METHODS:
                 return response
 
-            if response.get('content-type') in ('application/json', 'application/vnd.api+json',):
-                if getattr(response, 'streaming', False):
+            if response.get('content-type') in ('application/json', 'application/vnd.api+json', 'application/gzip'):
+                
+                if response.get('content-type') == 'application/gzip':
+                    response_body = '** GZIP Archive **'
+                elif getattr(response, 'streaming', False):
                     response_body = '** Streaming **'
                 else:
                     if type(response.content) == bytes:

--- a/drf_api_logger/utils.py
+++ b/drf_api_logger/utils.py
@@ -47,13 +47,20 @@ def database_log_enabled():
     return drf_api_logger_database
 
 
-def mask_sensitive_data(data):
+def mask_sensitive_data(data, mask_api_parameters=False):
     """
     Hides sensitive keys specified in sensitive_keys settings.
     Loops recursively over nested dictionaries.
+
+    When the mask_api_parameters parameter is set, the function will 
+    instead iterate over sensitive_keys and remove them from an api 
+    URL string.
     """
 
     if type(data) != dict:
+        if mask_api_parameters and type(data) == str:
+            for sensitive_key in SENSITIVE_KEYS:
+                data = re.sub('({}=)(.*?)($|&)'.format(sensitive_key), '\g<1>***FILTERED***\g<3>'.format(sensitive_key.upper()), data)
         return data
 
     for key, value in data.items():


### PR DESCRIPTION
Previously, if an access key or other sensitive data was included in a GET parameter, it would be included in the log as part of the API URL. This change allows the logger to replace sensitive values the API URL field with ***FILTERED*** just like in other parts of the log.