### PR TITLE
Added support for application/octet-stream

### DIFF
--- a/drf_api_logger/middleware/api_logger_middleware.py
+++ b/drf_api_logger/middleware/api_logger_middleware.py
@@ -106,6 +106,8 @@ class APILoggerMiddleware:
                 
                 if response.get('content-type') == 'application/gzip':
                     response_body = '** GZIP Archive **'
+                elif response.get('content-type') == 'application/octet-stream':
+                    response_body = '** Binary File **'
                 elif getattr(response, 'streaming', False):
                     response_body = '** Streaming **'
                 else:

--- a/drf_api_logger/middleware/api_logger_middleware.py
+++ b/drf_api_logger/middleware/api_logger_middleware.py
@@ -102,7 +102,7 @@ class APILoggerMiddleware:
             if len(self.DRF_API_LOGGER_METHODS) > 0 and method not in self.DRF_API_LOGGER_METHODS:
                 return response
 
-            if response.get('content-type') in ('application/json', 'application/vnd.api+json', 'application/gzip'):
+            if response.get('content-type') in ('application/json', 'application/vnd.api+json', 'application/gzip', 'application/octet-stream'):
                 
                 if response.get('content-type') == 'application/gzip':
                     response_body = '** GZIP Archive **'


### PR DESCRIPTION
Added support for _application/octet-stream_.

As _application/octet-stream_ are binary file(s), and are unknown and requires the receiver to determine, the response_body is set to have a generic message of "** Binary File **".

Use-cases : 
- For users who want to track PDF / document downloads through the API.
- For GTFS-R purposes, where response format is protobuf