### PR TITLE
Update chartData date value

### DIFF
--- a/drf_api_logger/templates/charts_change_list.html
+++ b/drf_api_logger/templates/charts_change_list.html
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const chartData = [
     {% for item in analytics %}
-    {"date": "{{ item.added_on__date }}", "y": {{ item.total }}},
+    {"date": "{{ item.added_on__date.isoformat }}", "y": {{ item.total }}},
     {% endfor %}
   ];
 


### PR DESCRIPTION
I noticed that if in the file settings.py LANGUAGE_CODE = 'ru' then the table "Number of API calls" cannot display statistics because JS cannot convert the date (Invalid Date).
The solution is to explicitly specify .isoformat ("date": "{{ item.added_on__date.isoformat }}"), then everything works.