### PR TITLE
Update README.md - change HTTP status codes to integers

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ DRF_API_LOGGER_METHODS = ['GET', 'POST', 'DELETE', 'PUT']  # Default to empty li
 ### Want to log only selected response status codes? (Optional)
 You can log only selected responses by specifying `DRF_API_LOGGER_STATUS_CODES` in settings.py.
 ```python
-DRF_API_LOGGER_STATUS_CODES = ['200', '400', '404', '500']  # Default to empty list (Log all responses).
+DRF_API_LOGGER_STATUS_CODES = [200, 400, 404, 500]  # Default to empty list (Log all responses).
 ```
 
 ### Want to see the API information in local timezone? (Optional)


### PR DESCRIPTION
Change HTTP status codes to ints.

Using strings does not work, as far as I can tell. This is causing confusion and not allowing logs to make it to the database 