### PR TITLE
Fix: invoke custom_handler in put_log_data (fixes #113)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 drf_api_logger.egg-info/
 .idea/
+__pycache__/

--- a/drf_api_logger/insert_log_into_database.py
+++ b/drf_api_logger/insert_log_into_database.py
@@ -73,6 +73,8 @@ class InsertLogIntoDatabase(Thread):
         Args:
             data (dict): Dictionary containing fields for APILogsModel.
         """
+        if self.custom_handler:
+            data = self.custom_handler(data)
         self._queue.put(APILogsModel(**data))
 
         # If queue is full, trigger immediate flush to the DB


### PR DESCRIPTION
## Summary

- **Fix #113**: `DRF_API_LOGGER_CUSTOM_HANDLER` was imported and stored in `InsertLogIntoDatabase.__init__()` but never actually called in `put_log_data()`. Added the missing invocation so the custom handler is called to enrich/modify log data before it's queued for database insertion.
- Add `__pycache__/` to `.gitignore` (was missing).

## Test plan

- [ ] Verify existing tests pass (no regressions — the 20 pre-existing test failures on `main` are unrelated)
- [ ] Configure `DRF_API_LOGGER_CUSTOM_HANDLER` in Django settings pointing to a function that modifies log data, and confirm the handler is called before logs are saved
- [ ] Confirm that when `DRF_API_LOGGER_CUSTOM_HANDLER` is not set, logging behavior is unchanged

https://claude.ai/code/session_01Xm34otsnCyKstNXxvzgABT