### PR TITLE
Fix profiling migration defaults for large MySQL upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DRF API Logger
 
-[![Version](https://img.shields.io/badge/version-1.2.1-blue.svg)](https://github.com/vishalanandl177/DRF-API-Logger)
+[![Version](https://img.shields.io/badge/version-1.2.2-blue.svg)](https://github.com/vishalanandl177/DRF-API-Logger)
 [![Python](https://img.shields.io/badge/python-3.6+-blue.svg)](https://www.python.org)
 [![Django](https://img.shields.io/badge/django-3.2+-green.svg)](https://djangoproject.com)
 [![DRF](https://img.shields.io/badge/djangorestframework-3.12+-orange.svg)](https://www.django-rest-framework.org)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,33 @@ If using database logging, run migrations:
 python manage.py migrate
 ```
 
+> **Upgrade warning for large MySQL/MariaDB tables:** Version 1.2.0+ adds
+> profiling-related columns (`profiling_data` and `sql_query_count`) to the
+> `drf_api_logs` table. On large MySQL/MariaDB tables, adding columns can take
+> locks or require table rebuilds depending on the database version, storage
+> engine, row format, and existing table definition. Plan this migration like a
+> production schema change.
+>
+> Before upgrading, inspect the SQL Django will run:
+>
+> ```bash
+> python manage.py sqlmigrate drf_api_logger 0003
+> ```
+>
+> For large MySQL/MariaDB deployments, validate the generated SQL against your
+> exact database/version, prefer database-native online DDL where supported, and
+> consider manually adding the columns with a safe online schema migration tool
+> or database-native online DDL. If the columns are added manually, fake-apply
+> the Django migration afterward:
+>
+> ```bash
+> python manage.py migrate drf_api_logger 0003 --fake
+> ```
+>
+> Avoid copying a generic `ALTER TABLE` command without validating it for your
+> database. MySQL and MariaDB online DDL behavior differs by version and table
+> definition.
+
 ## ⚙️ Quick Start
 
 ### Database Logging

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'DRF API Logger'
 copyright = '2020, Vishal Anand'
 author = 'Vishal Anand'
-release = '1.2.0'
+release = '1.2.2'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 DRF API Logger
 ==============
 
-.. image:: https://img.shields.io/badge/version-1.2.0-blue.svg
+.. image:: https://img.shields.io/badge/version-1.2.2-blue.svg
    :alt: Version
 .. image:: https://static.pepy.tech/personalized-badge/drf-api-logger?period=total&units=none&left_color=black&right_color=orange&left_text=Downloads%20Total
    :target: http://pepy.tech/project/drf-api-logger

--- a/drf_api_logger/migrations/0001_initial.py
+++ b/drf_api_logger/migrations/0001_initial.py
@@ -29,6 +29,7 @@ class Migration(migrations.Migration):
                 'verbose_name': 'API Log',
                 'verbose_name_plural': 'API Logs',
                 'db_table': 'drf_api_logs',
+                'ordering': ('-added_on',),
             },
         ),
     ]

--- a/drf_api_logger/migrations/0003_apilogsmodel_profiling.py
+++ b/drf_api_logger/migrations/0003_apilogsmodel_profiling.py
@@ -11,11 +11,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='apilogsmodel',
             name='profiling_data',
-            field=models.TextField(blank=True, default=None, null=True),
+            field=models.TextField(blank=True, null=True),
         ),
         migrations.AddField(
             model_name='apilogsmodel',
             name='sql_query_count',
-            field=models.PositiveIntegerField(blank=True, default=None, null=True),
+            field=models.PositiveIntegerField(blank=True, null=True),
         ),
     ]

--- a/drf_api_logger/models.py
+++ b/drf_api_logger/models.py
@@ -80,12 +80,10 @@ if database_log_enabled():
         profiling_data = models.TextField(
             null=True,
             blank=True,
-            default=None,
         )
         sql_query_count = models.PositiveIntegerField(
             null=True,
             blank=True,
-            default=None,
         )
 
         def __str__(self):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def get_long_desc():
 
 setuptools.setup(
     name="drf-api-logger",
-    version="1.2.1",
+    version="1.2.2",
     author="Vishal Anand",
     author_email="vishalanandl177@gmail.com",
     description="An API Logger for your Django Rest Framework project.",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ Test cases for Models and Admin
 from django.test import TestCase, RequestFactory
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
+from django.db.models.fields import NOT_PROVIDED
 from django.utils import timezone
 from django.test.utils import override_settings
 from unittest.mock import Mock, patch
@@ -151,6 +152,21 @@ class TestModels(TestCase):
         log.save()
         
         self.assertEqual(len(log.api), 1024)
+
+    def test_profiling_fields_are_nullable_without_model_defaults(self):
+        """Profiling fields should allow NULL without adding Python defaults."""
+        if not database_log_enabled():
+            self.skipTest("Database logging is not enabled")
+
+        profiling_field = self.APILogsModel._meta.get_field('profiling_data')
+        sql_query_count_field = self.APILogsModel._meta.get_field('sql_query_count')
+
+        self.assertTrue(profiling_field.null)
+        self.assertTrue(profiling_field.blank)
+        self.assertIs(profiling_field.default, NOT_PROVIDED)
+        self.assertTrue(sql_query_count_field.null)
+        self.assertTrue(sql_query_count_field.blank)
+        self.assertIs(sql_query_count_field.default, NOT_PROVIDED)
 
 
 @override_settings(DRF_API_LOGGER_DATABASE=True)


### PR DESCRIPTION
## Summary
- remove `default=None` from the existing `0003_apilogsmodel_profiling` migration and matching model fields while keeping them nullable/blankable
- align historical migration state metadata so `makemigrations --check --dry-run` stays clean without creating a new migration
- document the 1.2.0+ profiling-column upgrade risk for large MySQL/MariaDB tables, including `sqlmigrate`, online DDL planning, and fake-apply guidance
- add a regression test that verifies profiling fields remain nullable without Python-level defaults
- bump package/docs version markers to `1.2.2`

Closes #121

## Validation
- `git diff --check`
- `rg -n "default=None" drf_api_logger\migrations\0003_apilogsmodel_profiling.py drf_api_logger\models.py` returned no matches
- `J:\projects\drf-demo\venv\Scripts\python.exe -m django test tests --settings=tests.test_settings --verbosity=1` -> 143 tests passed
- `J:\projects\drf-demo\venv\Scripts\python.exe -m django makemigrations drf_api_logger --check --dry-run --settings=tests.test_settings` -> no changes detected
- `J:\projects\drf-demo\venv\Scripts\python.exe -m django sqlmigrate drf_api_logger 0003 --settings=tests.test_settings` -> nullable column additions with no defaults
- `J:\projects\drf-demo\venv\Scripts\python.exe -m django migrate drf_api_logger --plan --settings=tests.test_settings`
- `C:\Users\ALKETRON\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe setup.py --version` -> `1.2.2`