### PR TITLE
Prettify headers/body/response JSON in API log admin

### DIFF
--- a/drf_api_logger/admin.py
+++ b/drf_api_logger/admin.py
@@ -4,8 +4,44 @@ from django.conf import settings
 from django.contrib import admin
 from django.db.models import Count, Avg
 from django.http import HttpResponse
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from drf_api_logger.utils import database_log_enabled
+
+
+def _prettify_json_field(value):
+    """
+    Render a stored log field (headers / body / response) as a pretty-printed,
+    HTML-escaped JSON block for the admin change form.
+
+    The middleware already stores these as indented JSON, but plain/large or
+    non-JSON payloads (truncation markers, XML, streaming placeholders, ...) are
+    handled gracefully. The returned markup is wrapped in ``<pre class="apilogs-json">``
+    which the change-form template syntax-highlights on the client side. No size
+    limit is applied here so even large bodies are prettified in full.
+    """
+    if value is None or value == '':
+        return mark_safe('<div class="apilogs-empty">— empty —</div>')
+
+    text = value if isinstance(value, str) else str(value)
+    stripped = text.strip()
+
+    # Special placeholders emitted by the middleware, e.g.
+    # "** Response body truncated: 70000 bytes exceeds 65536 byte limit **".
+    is_marker = stripped.startswith('**') and stripped.endswith('**')
+
+    badge = ''
+    if is_marker and 'truncated' in stripped.lower():
+        badge = '<div class="apilogs-truncated">TRUNCATED</div>'
+
+    pretty = text
+    if not is_marker:
+        try:
+            pretty = json.dumps(json.loads(text), indent=2, ensure_ascii=False)
+        except (ValueError, TypeError):
+            pretty = text  # leave non-JSON payloads (XML, plain text, ...) as-is
+
+    return mark_safe('{}<pre class="apilogs-json">{}</pre>'.format(badge, escape(pretty)))
 
 
 def _get_profiling_diagnosis(profiling):
@@ -174,10 +210,13 @@ if database_log_enabled():
                     self.list_filter += (HighQueryCountFilter,)
                     self.readonly_fields = (
                         'execution_time', 'client_ip_address', 'api',
-                        'headers', 'body', 'method', 'response', 'status_code',
-                        'added_on_time', 'profiling_breakdown',
+                        'headers_prettified', 'body_prettified', 'method', 'response_prettified',
+                        'status_code', 'added_on_time', 'profiling_breakdown',
                     )
-                    self.exclude = ('added_on', 'profiling_data', 'sql_query_count')
+                    self.exclude = (
+                        'added_on', 'profiling_data', 'sql_query_count',
+                        'headers', 'body', 'response',
+                    )
 
         def added_on_time(self, obj):
             """
@@ -311,6 +350,21 @@ if database_log_enabled():
 
         profiling_breakdown.short_description = 'Profiling Breakdown'
 
+        def headers_prettified(self, obj):
+            return _prettify_json_field(obj.headers)
+
+        headers_prettified.short_description = 'Headers'
+
+        def body_prettified(self, obj):
+            return _prettify_json_field(obj.body)
+
+        body_prettified.short_description = 'Body'
+
+        def response_prettified(self, obj):
+            return _prettify_json_field(obj.response)
+
+        response_prettified.short_description = 'Response'
+
         # Admin UI settings
         list_per_page = 20
         list_display = ('id', 'api', 'method', 'status_code', 'execution_time', 'added_on_time',)
@@ -318,9 +372,10 @@ if database_log_enabled():
         search_fields = ('body', 'response', 'headers', 'api',)
         readonly_fields = (
             'execution_time', 'client_ip_address', 'api',
-            'headers', 'body', 'method', 'response', 'status_code', 'added_on_time',
+            'headers_prettified', 'body_prettified', 'method', 'response_prettified',
+            'status_code', 'added_on_time',
         )
-        exclude = ('added_on',)
+        exclude = ('added_on', 'headers', 'body', 'response')
 
         # Custom admin templates
         change_list_template = 'charts_change_list.html'

--- a/drf_api_logger/templates/change_form.html
+++ b/drf_api_logger/templates/change_form.html
@@ -1,8 +1,96 @@
 {% extends 'admin/change_form.html' %}
 
+{% block extrahead %}
+{{ block.super }}
+<style>
+  .apilogs-json {
+    background: #1e1e2e;
+    color: #cdd6f4;
+    font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 13px;
+    line-height: 1.6;
+    padding: 14px 16px;
+    border-radius: 6px;
+    border: 1px solid #313244;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow: auto;
+    max-height: 600px;
+    margin: 4px 0;
+    tab-size: 2;
+  }
+
+  .apilogs-empty {
+    color: #888;
+    font-style: italic;
+  }
+
+  .apilogs-truncated {
+    display: inline-block;
+    background: #f38ba8;
+    color: #1e1e2e;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 4px;
+    margin-bottom: 8px;
+    font-family: sans-serif;
+  }
+
+  /* Syntax colouring applied by JS below */
+  .apilogs-key    { color: #89b4fa; }
+  .apilogs-str    { color: #a6e3a1; }
+  .apilogs-num    { color: #fab387; }
+  .apilogs-bool   { color: #cba6f7; }
+  .apilogs-null   { color: #f38ba8; }
+  .apilogs-punct  { color: #6c7086; }
+</style>
+{% endblock %}
+
 {% block submit_buttons_bottom %}
     {{ block.super }}
     <div class="submit-row">
         <a href="?export=true">Export CSV</a>
     </div>
+{% endblock %}
+
+{% block content %}
+{{ block.super }}
+<script>
+(function () {
+  // Escape HTML first so values containing <, > or & are rendered safely and
+  // never break out of the <pre> (no XSS, even for large response bodies).
+  function escapeHtml(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  // Single-pass JSON tokeniser. Strings are matched whole, so braces/brackets
+  // that live inside a string value are never mistaken for structural
+  // punctuation. Works on arbitrarily large bodies.
+  var TOKEN = /("(\\u[a-fA-F0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(?:true|false)\b|\bnull\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?|[{}\[\],])/g;
+
+  function highlight(pre) {
+    var raw = pre.textContent;
+    try { JSON.parse(raw); } catch (e) { return; }  // leave non-JSON untouched
+
+    pre.innerHTML = escapeHtml(raw).replace(TOKEN, function (match) {
+      var cls;
+      if (match.charAt(0) === '"') {
+        cls = /:\s*$/.test(match) ? 'apilogs-key' : 'apilogs-str';
+      } else if (match === 'true' || match === 'false') {
+        cls = 'apilogs-bool';
+      } else if (match === 'null') {
+        cls = 'apilogs-null';
+      } else if (/^[{}\[\],]$/.test(match)) {
+        cls = 'apilogs-punct';
+      } else {
+        cls = 'apilogs-num';
+      }
+      return '<span class="' + cls + '">' + match + '</span>';
+    });
+  }
+
+  document.querySelectorAll('.apilogs-json').forEach(highlight);
+})();
+</script>
 {% endblock %}

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -164,12 +164,17 @@ class TestBackwardCompatAdmin(TestCase):
         from django.contrib.admin.sites import AdminSite
 
         admin = APILogsAdmin(APILogsModel, AdminSite())
+        # headers/body/response are rendered through prettified, syntax-highlighted
+        # readonly methods instead of the raw model fields (which are excluded).
         expected = (
             'execution_time', 'client_ip_address', 'api',
-            'headers', 'body', 'method', 'response', 'status_code', 'added_on_time',
+            'headers_prettified', 'body_prettified', 'method', 'response_prettified',
+            'status_code', 'added_on_time',
         )
         self.assertEqual(admin.readonly_fields, expected)
         self.assertNotIn('profiling_breakdown', admin.readonly_fields)
+        for raw_field in ('headers', 'body', 'response'):
+            self.assertIn(raw_field, admin.exclude)
 
     @override_settings(DRF_API_LOGGER_ENABLE_PROFILING=True)
     def test_admin_with_profiling_enabled(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -233,6 +233,74 @@ class TestAdmin(TestCase):
         self.assertIn('client_ip_address', readonly)
         self.assertIn('api', readonly)
 
+    def test_admin_prettifies_json_fields(self):
+        """headers/body/response render as highlighted, pretty-printed JSON blocks"""
+        if not database_log_enabled():
+            self.skipTest("Database logging is not enabled")
+
+        obj = self.APILogsModel(
+            api='http://testserver/api/',
+            headers='{"Content-Type": "application/json"}',
+            body='{"a": 1, "b": [1, 2, 3]}',
+            response='{"ok": true, "value": null, "count": 42}',
+            method='POST',
+            client_ip_address='127.0.0.1',
+            status_code=200,
+            execution_time=0.1,
+            added_on=timezone.now(),
+        )
+
+        rendered = str(self.admin.response_prettified(obj))
+        self.assertIn('apilogs-json', rendered)
+        # Compact stored JSON is re-indented for readability (quotes are escaped).
+        self.assertIn('\n  &quot;ok&quot;', rendered)
+
+    def test_admin_prettify_escapes_html(self):
+        """Values containing HTML are escaped so they cannot break out of <pre>"""
+        if not database_log_enabled():
+            self.skipTest("Database logging is not enabled")
+
+        from drf_api_logger.admin import _prettify_json_field
+
+        rendered = str(_prettify_json_field('{"x": "<script>alert(1)</script>"}'))
+        self.assertNotIn('<script>', rendered)
+        self.assertIn('&lt;script&gt;', rendered)
+
+    def test_admin_prettify_empty_value(self):
+        """Empty fields render an explicit empty placeholder, not an empty <pre>"""
+        if not database_log_enabled():
+            self.skipTest("Database logging is not enabled")
+
+        from drf_api_logger.admin import _prettify_json_field
+
+        for empty in ('', None):
+            rendered = str(_prettify_json_field(empty))
+            self.assertIn('apilogs-empty', rendered)
+            self.assertNotIn('apilogs-json', rendered)
+
+    def test_admin_prettify_truncation_marker(self):
+        """Truncation markers keep a badge and are not mangled as JSON"""
+        if not database_log_enabled():
+            self.skipTest("Database logging is not enabled")
+
+        from drf_api_logger.admin import _prettify_json_field
+
+        marker = '** Response body truncated: 70000 bytes exceeds 65536 byte limit **'
+        rendered = str(_prettify_json_field(marker))
+        self.assertIn('apilogs-truncated', rendered)
+        self.assertIn(marker, rendered)
+
+    def test_admin_prettify_non_json_passthrough(self):
+        """Non-JSON payloads (e.g. XML) are shown as-is, escaped, without errors"""
+        if not database_log_enabled():
+            self.skipTest("Database logging is not enabled")
+
+        from drf_api_logger.admin import _prettify_json_field
+
+        rendered = str(_prettify_json_field('<note><to>Tove</to></note>'))
+        self.assertIn('apilogs-json', rendered)
+        self.assertIn('&lt;note&gt;', rendered)
+
     def test_admin_has_add_permission(self):
         """Test that add permission is disabled"""
         if not database_log_enabled():


### PR DESCRIPTION
## What & why
The Headers, Body and Response fields on the API log change page were shown as
raw, unformatted text. This renders them as indented, syntax-highlighted JSON,
so logs are far easier to read.

## Changes
- **admin**: new `_prettify_json_field` helper + `headers_prettified`,
  `body_prettified`, `response_prettified` readonly methods. They pretty-print
  (`json.dumps(indent=2)`) and HTML-escape the stored value, wrapped in
  `<pre class="apilogs-json">`. Empty values, middleware truncation/placeholder
  markers, and non-JSON payloads (XML, streaming/binary) are handled gracefully.
  No display-side size cap — large bodies are formatted in full. Raw fields moved
  to `exclude`.
- **template** (`change_form.html`): dark JSON theme + a client-side highlighter
  that HTML-escapes before colouring (XSS-safe) and tokenises in a single pass so
  punctuation inside string values isn't mis-coloured. Existing Export CSV button
  retained.
- **tests**: cover pretty-printing, HTML escaping, empty values, truncation
  markers and non-JSON passthrough; update the backward-compat readonly-fields
  assertion.

## Notes
- Works for the profiling-enabled admin layout too.
- Full test suite passes (148 tests).
- "Big bodies" display fully; the only thing showing a `TRUNCATED` badge is a body
  the middleware discarded at capture time via `DRF_API_LOGGER_MAX_RESPONSE_BODY_SIZE`
  (a capture-side setting, unchanged here).