### PR TITLE
[SCRUM-14] Improve admin graph lazy loading UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ DRF_API_LOGGER_DATABASE = True
 - 🎛️ **Smart Filtering**: Filter by date, status code, HTTP method, and performance
 - 📈 **Visual Analytics**: Built-in performance charts and statistics
 
+Admin graphs are collapsed by default and loaded on demand when opened, keeping
+the log list fast and focused during routine investigation. Each graph has its
+own control and fetches its backend data only when opened; graph data requests
+time out after 30 seconds.
+
 ### Admin Dashboard Screenshots
 
 **Admin Home**

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,6 +110,10 @@ Enable database storage for API logs:
    DRF_API_LOGGER_DATABASE = True  # Default: False
 
 Logs will be available in the Django Admin Panel with search, filtering, and analytics charts.
+Admin graphs are collapsed by default and loaded on demand when opened, keeping
+the log list fast and focused during routine investigation. Each graph has its
+own control and fetches its backend data only when opened; graph data requests
+time out after 30 seconds.
 
 .. note::
 

--- a/drf_api_logger/admin.py
+++ b/drf_api_logger/admin.py
@@ -3,7 +3,8 @@ from datetime import timedelta
 from django.conf import settings
 from django.contrib import admin
 from django.db.models import Count, Avg
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse, JsonResponse
+from django.urls import path
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from drf_api_logger.utils import database_log_enabled
@@ -390,46 +391,89 @@ if database_log_enabled():
         change_form_template = 'change_form.html'
         date_hierarchy = 'added_on'
 
+        def get_urls(self):
+            urls = super().get_urls()
+            opts = self.model._meta
+            custom_urls = [
+                path(
+                    'chart-data/<slug:chart_name>/',
+                    self.admin_site.admin_view(self.chart_data_view),
+                    name='{}_{}_chart_data'.format(opts.app_label, opts.model_name),
+                ),
+            ]
+            return custom_urls + urls
+
         def changelist_view(self, request, extra_context=None):
             """
-            Override to inject custom chart data for status codes and analytics into the context.
+            Add lightweight chart configuration without precomputing chart data.
             """
             response = super(APILogsAdmin, self).changelist_view(request, extra_context)
             try:
-                filtered_query_set = response.context_data["cl"].queryset
+                response.context_data
             except Exception:
                 return response
 
-            # Aggregate logs by date
-            analytics_model = filtered_query_set.values('added_on__date').annotate(
-                total=Count('id')
-            ).order_by('total')
-
-            # Count each unique status code
-            status_code_count_mode = filtered_query_set.values('id').values('status_code').annotate(
-                total=Count('id')).order_by('status_code')
-
-            status_code_count_keys = [item.get('status_code') for item in status_code_count_mode]
-            status_code_count_values = [item.get('total') for item in status_code_count_mode]
-
-            # Add chart data to context
-            extra_context = dict(
-                analytics=analytics_model,
-                status_code_count_keys=status_code_count_keys,
-                status_code_count_values=status_code_count_values
-            )
-
-            # Add profiling chart data when profiling is enabled
-            if self._DRF_API_LOGGER_ENABLE_PROFILING:
-                profiled_qs = filtered_query_set.filter(sql_query_count__isnull=False)
-                sql_distribution = profiled_qs.values('added_on__date').annotate(
-                    avg_queries=Avg('sql_query_count')
-                ).order_by('added_on__date')
-                extra_context['sql_distribution'] = list(sql_distribution)
-                extra_context['profiling_enabled'] = True
-
-            response.context_data.update(extra_context)
+            response.context_data.update({
+                'profiling_enabled': bool(
+                    getattr(settings, 'DRF_API_LOGGER_ENABLE_PROFILING', False)
+                ),
+            })
             return response
+
+        def chart_data_view(self, request, chart_name):
+            queryset = self.get_changelist_instance(request).queryset
+            if chart_name == 'api-calls-by-day':
+                return JsonResponse(self._api_calls_by_day_chart_data(queryset))
+            if chart_name == 'api-calls-by-status-code':
+                return JsonResponse(self._api_calls_by_status_code_chart_data(queryset))
+            if chart_name == 'sql-queries-by-day':
+                if not getattr(settings, 'DRF_API_LOGGER_ENABLE_PROFILING', False):
+                    raise Http404('Chart is not available when profiling is disabled.')
+                return JsonResponse(self._sql_queries_by_day_chart_data(queryset))
+            raise Http404('Unknown chart.')
+
+        def _api_calls_by_day_chart_data(self, queryset):
+            rows = queryset.values('added_on__date').annotate(
+                total=Count('id')
+            ).order_by('added_on__date')
+            return {
+                'chart': 'api-calls-by-day',
+                'label': 'Number of API calls',
+                'data': [
+                    {
+                        'x': item['added_on__date'].isoformat(),
+                        'y': item['total'],
+                    }
+                    for item in rows
+                ],
+            }
+
+        def _api_calls_by_status_code_chart_data(self, queryset):
+            rows = queryset.values('status_code').annotate(
+                total=Count('id')
+            ).order_by('status_code')
+            return {
+                'chart': 'api-calls-by-status-code',
+                'label': 'Number of API calls by status code',
+                'labels': [item['status_code'] for item in rows],
+                'values': [item['total'] for item in rows],
+            }
+
+        def _sql_queries_by_day_chart_data(self, queryset):
+            rows = queryset.filter(sql_query_count__isnull=False).values(
+                'added_on__date'
+            ).annotate(avg_queries=Avg('sql_query_count')).order_by('added_on__date')
+            return {
+                'chart': 'sql-queries-by-day',
+                'label': 'Avg SQL queries per request',
+                'data': [
+                    {
+                        'x': item['added_on__date'].isoformat(),
+                        'y': round(float(item['avg_queries']), 1),
+                    }
+                    for item in rows
+                ],
+            }
 
         def get_queryset(self, request):
             """

--- a/drf_api_logger/templates/charts_change_list.html
+++ b/drf_api_logger/templates/charts_change_list.html
@@ -1,162 +1,326 @@
 {% extends "admin/change_list.html" %}
 {% load static %}
 
-<!-- Override extrahead to add Chart.js -->
+<!-- Override extrahead to add chart assets and per-graph lazy rendering. -->
 {% block extrahead %}
 {{ block.super }}
 <link rel="stylesheet" href="{% static "drf_api_logger/css/Chart.min.css" %}" />
-<script src="{% static "drf_api_logger/js/Chart.bundle.min.js" %}"></script>
+<style>
+  .api-log-chart-summary {
+    border: 1px solid var(--hairline-color, #d8d8d8);
+    border-radius: 4px;
+    margin: 0 0 16px;
+    padding: 12px 16px;
+    background: var(--body-bg, #fff);
+  }
+
+  .api-log-chart-summary p {
+    margin: 0 0 10px;
+    color: var(--body-quiet-color, #666);
+  }
+
+  .api-log-chart-card {
+    border: 1px solid var(--hairline-color, #d8d8d8);
+    border-radius: 4px;
+    box-sizing: border-box;
+    margin: 0 0 14px;
+    padding: 14px 16px;
+    width: 100%;
+    background: var(--body-bg, #fff);
+  }
+
+  .api-log-chart-card-header {
+    align-items: center;
+    display: flex;
+    gap: 12px;
+    justify-content: space-between;
+  }
+
+  .api-log-chart-card h2 {
+    font-size: 14px;
+    margin: 0;
+  }
+
+  .api-log-chart-toggle {
+    border: 1px solid var(--border-color, #ccc);
+    border-radius: 4px;
+    padding: 6px 12px;
+    cursor: pointer;
+    background: var(--button-bg, #417690);
+    color: var(--button-fg, #fff);
+    font: inherit;
+  }
+
+  .api-log-chart-toggle:hover,
+  .api-log-chart-toggle:focus {
+    background: var(--button-hover-bg, #205067);
+  }
+
+  .api-log-chart-panel {
+    height: 200px;
+    margin-top: 14px;
+    max-height: 200px;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .api-log-chart-panel[hidden],
+  .api-log-chart-message[hidden] {
+    display: none;
+  }
+
+  .api-log-chart-panel canvas {
+    display: block;
+    height: 200px !important;
+    max-height: 200px;
+    width: 100% !important;
+  }
+
+  .api-log-chart-message {
+    color: var(--body-quiet-color, #666);
+    margin: 12px 0 0;
+  }
+</style>
 <script>
-
 document.addEventListener('DOMContentLoaded', () => {
-  const ctx = document.getElementById('countChart').getContext('2d');
+  const chartScriptUrl = '{% static "drf_api_logger/js/Chart.bundle.min.js" %}';
+  const graphApiTimeoutMs = 30000;
+  let chartScriptLoading = null;
 
-  const chartData = [
-    {% for item in analytics %}
-    {"date": "{{ item.added_on__date.isoformat }}", "y": {{ item.total }}},
-    {% endfor %}
-  ];
+  document.querySelectorAll('.api-log-chart-toggle').forEach((toggle) => {
+    toggle.addEventListener('click', () => {
+      const card = toggle.closest('.api-log-chart-card');
+      const panel = card.querySelector('.api-log-chart-panel');
+      const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
 
-  // Parse the dates to JS
-  chartData.forEach((d) => {
-    d.x = new Date(d.date);
+      toggle.setAttribute('aria-expanded', String(!isExpanded));
+      toggle.textContent = isExpanded ? 'Show' : 'Hide';
+      panel.hidden = isExpanded;
+
+      if (!isExpanded && card.dataset.loaded !== 'true') {
+        loadChartData(card);
+      }
+    });
   });
 
-  // Render the chart
-  const chart = new Chart(ctx, {
-    type: 'bar',
-    data: {
-      datasets: [
-        {
-          label: 'Number of API calls',
+  function loadChartScript() {
+    if (window.Chart) {
+      return Promise.resolve();
+    }
+    if (chartScriptLoading) {
+      return chartScriptLoading;
+    }
+
+    chartScriptLoading = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = chartScriptUrl;
+      script.async = true;
+      script.onload = resolve;
+      script.onerror = reject;
+      document.head.appendChild(script);
+    });
+    return chartScriptLoading;
+  }
+
+  function buildChartUrl(card) {
+    const chartUrl = new URL(card.dataset.chartUrl, window.location.href);
+    chartUrl.search = window.location.search;
+    return chartUrl;
+  }
+
+  function loadChartData(card) {
+    if (card.dataset.loading === 'true') {
+      return;
+    }
+    card.dataset.loading = 'true';
+    showMessage(card, 'loading');
+
+    const chartUrl = buildChartUrl(card);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), graphApiTimeoutMs);
+    Promise.all([
+      loadChartScript(),
+      fetch(chartUrl, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        signal: controller.signal,
+      }),
+    ]).then((responses) => {
+      const response = responses[1];
+      if (!response.ok) {
+        throw new Error('Chart data request failed.');
+      }
+      return response.json();
+    }).then((payload) => {
+      clearTimeout(timeoutId);
+      renderCharts(card, payload);
+      card.dataset.loaded = 'true';
+      card.dataset.loading = 'false';
+      showMessage(card, null);
+    }).catch(() => {
+      clearTimeout(timeoutId);
+      card.dataset.loading = 'false';
+      showMessage(card, 'error');
+    });
+  }
+
+  function showMessage(card, role) {
+    card.querySelectorAll('.api-log-chart-message').forEach((message) => {
+      message.hidden = message.dataset.role !== role;
+    });
+  }
+
+  function renderCharts(card, payload) {
+    if (payload.chart === 'api-calls-by-day') {
+      renderTimeSeriesChart(card, payload);
+      return;
+    }
+    if (payload.chart === 'api-calls-by-status-code') {
+      renderStatusCodeChart(card, payload);
+      return;
+    }
+    if (payload.chart === 'sql-queries-by-day') {
+      renderTimeSeriesChart(card, payload);
+    }
+  }
+
+  function renderTimeSeriesChart(card, payload) {
+    const ctx = card.querySelector('canvas').getContext('2d');
+    const chartData = payload.data.map((item) => ({
+      x: new Date(item.x),
+      y: item.y,
+    }));
+
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        datasets: [{
+          label: payload.label,
           data: chartData,
-          backgroundColor: 'rgb(33,150,243)',
-        },
-      ],
-    },
-    options: {
-      responsive: true,
-      scales: {
-        xAxes: [
-          {
+          backgroundColor: payload.chart === 'sql-queries-by-day'
+            ? 'rgb(255, 152, 0)'
+            : 'rgb(33,150,243)',
+        }],
+      },
+      options: {
+        maintainAspectRatio: false,
+        responsive: true,
+        scales: {
+          xAxes: [{
             type: 'time',
             time: {
               unit: 'day',
               round: 'day',
               tooltipFormat:'DD/MM/YYYY',
-              displayFormats: {
-                day: 'MMM D',
-              },
+              displayFormats: { day: 'MMM D' },
             },
-          },
-        ],
-        yAxes: [
-          {
-            ticks: {
-              beginAtZero: true,
-            },
-          },
-        ],
+          }],
+          yAxes: [{
+            ticks: { beginAtZero: true },
+          }],
+        },
       },
-    },
-  });
+    });
+  }
 
-  var color = Chart.helpers.color;
-
-  var barChartData = {
-      labels: {{ status_code_count_keys }},
-      datasets: [{
-          label: 'Number of API calls by status code',
+  function renderStatusCodeChart(card, payload) {
+    const ctx = card.querySelector('canvas').getContext('2d');
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: payload.labels,
+        datasets: [{
+          label: payload.label,
           backgroundColor: 'rgb(33,150,243)',
           borderColor: 'rgb(33,150,243)',
           borderWidth: 1,
-          data: {{ status_code_count_values }}
-      }]
-  };
-
-  window.onload = function() {
-      var ctx = document.getElementById('statusCodeChart').getContext('2d');
-      window.myBar = new Chart(ctx, {
-          type: 'bar',
-          data: barChartData,
-          options: {
-              responsive: true,
-              legend: {
-                  position: 'top',
-              },
-              title: {
-                  display: true,
-                  text: 'API calls by status code'
-              }
-          }
-      });
-
-      {% if profiling_enabled and sql_distribution %}
-      var sqlCtx = document.getElementById('sqlQueryChart').getContext('2d');
-      var sqlChartData = [
-        {% for item in sql_distribution %}
-        {"date": "{{ item.added_on__date.isoformat }}", "y": {{ item.avg_queries|floatformat:1 }}},
-        {% endfor %}
-      ];
-
-      sqlChartData.forEach(function(d) {
-        d.x = new Date(d.date);
-      });
-
-      new Chart(sqlCtx, {
-        type: 'bar',
-        data: {
-          datasets: [{
-            label: 'Avg SQL queries per request',
-            data: sqlChartData,
-            backgroundColor: 'rgb(255, 152, 0)',
-          }]
+          data: payload.values,
+        }],
+      },
+      options: {
+        maintainAspectRatio: false,
+        responsive: true,
+        legend: { position: 'top' },
+        title: {
+          display: true,
+          text: 'API calls by status code',
         },
-        options: {
-          responsive: true,
-          scales: {
-            xAxes: [{
-              type: 'time',
-              time: {
-                unit: 'day',
-                round: 'day',
-                tooltipFormat: 'DD/MM/YYYY',
-                displayFormats: { day: 'MMM D' }
-              }
-            }],
-            yAxes: [{
-              ticks: { beginAtZero: true },
-              scaleLabel: {
-                display: true,
-                labelString: 'Queries'
-              }
-            }]
-          },
-          title: {
-            display: true,
-            text: 'Average SQL queries per request (daily)'
-          }
-        }
-      });
-      {% endif %}
-  };
+      },
+    });
+  }
 });
 </script>
 {% endblock %}
 
 {% block content %}
-<!-- Render our chart -->
-<div style="width: 80%;">
-  <canvas style="margin-bottom: 30px; width: 60%; height: 50%;" id="countChart"></canvas>
+<div class="api-log-chart-summary">
+  <p><strong>API log graphs</strong></p>
 </div>
-<div style="width: 80%; margin-top: 24px;">
-  <canvas style="margin-bottom: 30px; width: 60%; height: 50%;" id="statusCodeChart"></canvas>
+
+<div
+  class="api-log-chart-card"
+  data-chart="api-calls-by-day"
+  data-chart-url="chart-data/api-calls-by-day/"
+>
+  <div class="api-log-chart-card-header">
+    <h2>API calls by day</h2>
+    <button
+      type="button"
+      class="api-log-chart-toggle"
+      aria-controls="api-log-chart-api-calls-by-day"
+      aria-expanded="false"
+    >Show</button>
+  </div>
+  <p class="api-log-chart-message" data-role="loading" hidden>Loading graph data...</p>
+  <p class="api-log-chart-message" data-role="error" hidden>Graph data could not be loaded. Try again.</p>
+  <div class="api-log-chart-panel" id="api-log-chart-api-calls-by-day" hidden>
+    <canvas id="apiCallsByDayChart"></canvas>
+  </div>
 </div>
+
+<div
+  class="api-log-chart-card"
+  data-chart="api-calls-by-status-code"
+  data-chart-url="chart-data/api-calls-by-status-code/"
+>
+  <div class="api-log-chart-card-header">
+    <h2>API calls by status code</h2>
+    <button
+      type="button"
+      class="api-log-chart-toggle"
+      aria-controls="api-log-chart-api-calls-by-status-code"
+      aria-expanded="false"
+    >Show</button>
+  </div>
+  <p class="api-log-chart-message" data-role="loading" hidden>Loading graph data...</p>
+  <p class="api-log-chart-message" data-role="error" hidden>Graph data could not be loaded. Try again.</p>
+  <div class="api-log-chart-panel" id="api-log-chart-api-calls-by-status-code" hidden>
+    <canvas id="statusCodeChart"></canvas>
+  </div>
+</div>
+
 {% if profiling_enabled %}
-<div style="width: 80%; margin-top: 24px;">
-  <canvas style="margin-bottom: 30px; width: 60%; height: 50%;" id="sqlQueryChart"></canvas>
+<div
+  class="api-log-chart-card"
+  data-chart="sql-queries-by-day"
+  data-chart-url="chart-data/sql-queries-by-day/"
+>
+  <div class="api-log-chart-card-header">
+    <h2>Average SQL queries per request</h2>
+    <button
+      type="button"
+      class="api-log-chart-toggle"
+      aria-controls="api-log-chart-sql-queries-by-day"
+      aria-expanded="false"
+    >Show</button>
+  </div>
+  <p class="api-log-chart-message" data-role="loading" hidden>Loading graph data...</p>
+  <p class="api-log-chart-message" data-role="error" hidden>Graph data could not be loaded. Try again.</p>
+  <div class="api-log-chart-panel" id="api-log-chart-sql-queries-by-day" hidden>
+    <canvas id="sqlQueryChart"></canvas>
+  </div>
 </div>
 {% endif %}
+
 <!-- Render the rest of the ChangeList view -->
 {{ block.super }}
 {% endblock %}

--- a/tests/test_admin_charts.py
+++ b/tests/test_admin_charts.py
@@ -1,0 +1,142 @@
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from drf_api_logger.utils import database_log_enabled
+
+
+@override_settings(DRF_API_LOGGER_DATABASE=True)
+class AdminChartDataEndpointTests(TestCase):
+    def setUp(self):
+        if not database_log_enabled():
+            self.skipTest("Database logging is not enabled")
+
+        from drf_api_logger.models import APILogsModel
+
+        self.APILogsModel = APILogsModel
+        self.user = User.objects.create_superuser(
+            username="admin",
+            email="admin@test.com",
+            password="password",
+        )
+        self.client.force_login(self.user)
+        now = timezone.now()
+        self.APILogsModel.objects.create(
+            api="/api/one/",
+            headers="{}",
+            body="",
+            method="GET",
+            client_ip_address="127.0.0.1",
+            response="{}",
+            status_code=200,
+            execution_time=0.1,
+            added_on=now - timedelta(days=1),
+            sql_query_count=3,
+        )
+        self.APILogsModel.objects.create(
+            api="/api/two/",
+            headers="{}",
+            body="",
+            method="POST",
+            client_ip_address="127.0.0.1",
+            response="{}",
+            status_code=500,
+            execution_time=0.2,
+            added_on=now,
+            sql_query_count=11,
+        )
+        self.APILogsModel.objects.create(
+            api="/api/three/",
+            headers="{}",
+            body="",
+            method="GET",
+            client_ip_address="127.0.0.1",
+            response="{}",
+            status_code=500,
+            execution_time=0.3,
+            added_on=now,
+            sql_query_count=None,
+        )
+
+    def test_changelist_does_not_precompute_chart_data(self):
+        response = self.client.get(
+            reverse("admin:drf_api_logger_apilogsmodel_changelist")
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("analytics", response.context_data)
+        self.assertNotIn("status_code_count_keys", response.context_data)
+        self.assertNotIn("status_code_count_values", response.context_data)
+        self.assertNotIn("sql_distribution", response.context_data)
+
+    def test_api_calls_by_day_chart_data_uses_current_admin_filters(self):
+        response = self.client.get(
+            reverse(
+                "admin:drf_api_logger_apilogsmodel_chart_data",
+                args=["api-calls-by-day"],
+            ),
+            {"method__exact": "GET"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["chart"], "api-calls-by-day")
+        self.assertEqual(data["label"], "Number of API calls")
+        self.assertEqual(sum(item["y"] for item in data["data"]), 2)
+
+    def test_api_calls_by_status_code_chart_data_uses_current_admin_filters(self):
+        response = self.client.get(
+            reverse(
+                "admin:drf_api_logger_apilogsmodel_chart_data",
+                args=["api-calls-by-status-code"],
+            ),
+            {"method__exact": "GET"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["chart"], "api-calls-by-status-code")
+        self.assertEqual(data["labels"], [200, 500])
+        self.assertEqual(data["values"], [1, 1])
+
+    @override_settings(DRF_API_LOGGER_ENABLE_PROFILING=True)
+    def test_sql_queries_by_day_chart_data_requires_profiling_and_filters(self):
+        response = self.client.get(
+            reverse(
+                "admin:drf_api_logger_apilogsmodel_chart_data",
+                args=["sql-queries-by-day"],
+            ),
+            {"method__exact": "POST"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["chart"], "sql-queries-by-day")
+        self.assertEqual(data["label"], "Avg SQL queries per request")
+        self.assertEqual(len(data["data"]), 1)
+        self.assertEqual(data["data"][0]["y"], 11.0)
+
+    def test_unknown_chart_data_returns_404(self):
+        response = self.client.get(
+            reverse(
+                "admin:drf_api_logger_apilogsmodel_chart_data",
+                args=["private-fields"],
+            )
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_chart_data_requires_admin_authentication(self):
+        self.client.logout()
+
+        response = self.client.get(
+            reverse(
+                "admin:drf_api_logger_apilogsmodel_chart_data",
+                args=["api-calls-by-day"],
+            )
+        )
+
+        self.assertEqual(response.status_code, 302)

--- a/tests/test_admin_templates.py
+++ b/tests/test_admin_templates.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class AdminChartTemplateTests(SimpleTestCase):
+    def test_each_changelist_chart_has_its_own_collapsible_loader(self):
+        template = ROOT.joinpath(
+            "drf_api_logger", "templates", "charts_change_list.html"
+        ).read_text(encoding="utf-8")
+
+        for chart_name in (
+            "api-calls-by-day",
+            "api-calls-by-status-code",
+            "sql-queries-by-day",
+        ):
+            with self.subTest(chart_name=chart_name):
+                self.assertIn(f'data-chart="{chart_name}"', template)
+                self.assertIn(
+                    f'data-chart-url="chart-data/{chart_name}/"', template
+                )
+
+        self.assertIn('aria-expanded="false"', template)
+        self.assertIn('hidden', template)
+        self.assertIn("loadChartData(card)", template)
+        self.assertIn("fetch(chartUrl", template)
+        self.assertIn("card.dataset.loaded = 'true';", template)
+
+    def test_changelist_charts_do_not_embed_backend_datasets(self):
+        template = ROOT.joinpath(
+            "drf_api_logger", "templates", "charts_change_list.html"
+        ).read_text(encoding="utf-8")
+
+        self.assertNotIn("{% for item in analytics %}", template)
+        self.assertNotIn("{{ status_code_count_keys }}", template)
+        self.assertNotIn("{{ status_code_count_values }}", template)
+        self.assertNotIn("{% for item in sql_distribution %}", template)
+
+    def test_changelist_chart_cards_use_full_available_width(self):
+        template = ROOT.joinpath(
+            "drf_api_logger", "templates", "charts_change_list.html"
+        ).read_text(encoding="utf-8")
+
+        card_rule_start = template.find(".api-log-chart-card {")
+        card_rule_end = template.find("}", card_rule_start)
+
+        self.assertNotEqual(-1, card_rule_start)
+        self.assertNotEqual(-1, card_rule_end)
+
+        card_rule = template[card_rule_start:card_rule_end]
+        self.assertIn("width: 100%;", card_rule)
+        self.assertIn("box-sizing: border-box;", card_rule)
+        self.assertNotIn("max-width", card_rule)
+
+    def test_changelist_chart_panels_are_capped_to_200px_height(self):
+        template = ROOT.joinpath(
+            "drf_api_logger", "templates", "charts_change_list.html"
+        ).read_text(encoding="utf-8")
+
+        panel_rule_start = template.find(".api-log-chart-panel {")
+        panel_rule_end = template.find("}", panel_rule_start)
+        canvas_rule_start = template.find(".api-log-chart-panel canvas {")
+        canvas_rule_end = template.find("}", canvas_rule_start)
+
+        self.assertNotEqual(-1, panel_rule_start)
+        self.assertNotEqual(-1, panel_rule_end)
+        self.assertNotEqual(-1, canvas_rule_start)
+        self.assertNotEqual(-1, canvas_rule_end)
+
+        panel_rule = template[panel_rule_start:panel_rule_end]
+        canvas_rule = template[canvas_rule_start:canvas_rule_end]
+
+        self.assertIn("height: 200px;", panel_rule)
+        self.assertIn("max-height: 200px;", panel_rule)
+        self.assertIn("overflow: hidden;", panel_rule)
+        self.assertIn("height: 200px !important;", canvas_rule)
+        self.assertIn("max-height: 200px;", canvas_rule)
+        self.assertNotIn("min-height", canvas_rule)
+        self.assertEqual(2, template.count("maintainAspectRatio: false"))
+
+    def test_changelist_graph_api_fetch_has_30_second_timeout(self):
+        template = ROOT.joinpath(
+            "drf_api_logger", "templates", "charts_change_list.html"
+        ).read_text(encoding="utf-8")
+
+        load_chart_data_start = template.find("function loadChartData(card)")
+        render_charts_start = template.find("function showMessage")
+
+        self.assertNotEqual(-1, load_chart_data_start)
+        self.assertNotEqual(-1, render_charts_start)
+
+        load_chart_data = template[load_chart_data_start:render_charts_start]
+        self.assertIn("const graphApiTimeoutMs = 30000;", template)
+        self.assertIn("const controller = new AbortController();", load_chart_data)
+        self.assertIn(
+            "setTimeout(() => controller.abort(), graphApiTimeoutMs)",
+            load_chart_data,
+        )
+        self.assertIn("signal: controller.signal", load_chart_data)
+        self.assertIn("clearTimeout(timeoutId)", load_chart_data)
+
+    def test_changelist_charts_render_only_after_toggle_click(self):
+        template = ROOT.joinpath(
+            "drf_api_logger", "templates", "charts_change_list.html"
+        ).read_text(encoding="utf-8")
+
+        dom_ready_start = template.find("document.addEventListener('DOMContentLoaded'")
+        render_charts_start = template.find("function renderCharts")
+
+        self.assertNotEqual(-1, dom_ready_start)
+        self.assertNotEqual(-1, render_charts_start)
+
+        dom_ready_block = template[dom_ready_start:render_charts_start]
+
+        self.assertIn("toggle.addEventListener('click'", dom_ready_block)
+        self.assertNotIn("new Chart(", dom_ready_block)

--- a/tests/test_docs_content.py
+++ b/tests/test_docs_content.py
@@ -302,6 +302,17 @@ class DocumentationContentTests(unittest.TestCase):
         for content in (readme, quickstart, operations, testing, developer_testing, developer_testing_md):
             self.assertIn("ASGI", content)
 
+    def test_admin_chart_lazy_loading_is_documented(self):
+        readme = read_text("README.md")
+        index = read_text("docs/index.rst")
+
+        for content in (readme, index):
+            self.assertIn("collapsed by default", content)
+            self.assertIn("loaded on demand", content)
+            self.assertIn("Each graph", content)
+            self.assertIn("fetches its backend data only when opened", content)
+            self.assertIn("30 seconds", content)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This PR updates the Django admin API log graphs so the changelist stays fast and the graph UI is less intrusive.

- Makes each existing admin graph individually collapsible.
- Fetches graph data only when that specific graph is opened.
- Adds admin-only chart-data endpoints that reuse the current filtered changelist queryset.
- Keeps graph cards horizontally full width and caps expanded graph height at 200px.
- Applies a 30 second timeout only to graph data fetches in the admin chart UI.
- Documents the lazy graph behavior and timeout.

## Scope notes

- No model changes.
- No migrations.
- No package build or release publication.
- Existing unrelated untracked local files were left unstaged.

## Validation

- `python -m django test tests --settings=tests.test_settings --verbosity=1` - passed, 256 tests.
- `python -m django test tests.test_admin_templates tests.test_admin_charts --settings=tests.test_settings --verbosity=2` - passed, 12 tests.
- `python -m unittest tests.test_docs_content` - passed, 12 tests.
- `python -m django makemigrations drf_api_logger --check --dry-run --settings=tests.test_settings` - no changes detected.
- `python test_runner_simple.py` - passed, 27 tests.
- `git diff --check` - passed.
- Explicit search for advanced-query model/migration identifiers returned no matches.
- Demo app `J:\projects\drf-demo`: current branch installed editable, `manage.py check` passed, `collectstatic --noinput` passed, rendered admin changelist confirmed lazy graph timeout, full width, and 200px height.