### PR TITLE
Add safe Prometheus metrics and security signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DRF API Logger
 
-[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](https://github.com/vishalanandl177/DRF-API-Logger)
+[![Version](https://img.shields.io/badge/version-1.4.0-blue.svg)](https://github.com/vishalanandl177/DRF-API-Logger)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org)
 [![Django](https://img.shields.io/badge/django-4.2%2B-green.svg)](https://djangoproject.com)
 [![DRF](https://img.shields.io/badge/djangorestframework-3.16%2B-orange.svg)](https://www.django-rest-framework.org)
@@ -69,6 +69,7 @@ DRF API Logger automatically captures and stores comprehensive API information:
 - **Request Correlation**: Opt-in request IDs, traceparent parsing, route metadata, logging context, and signal metadata without new database columns
 - **ASGI-Native Logging**: Supports Django's async middleware chain with concurrent request context isolation
 - **Safe Observability Integrations**: Optional helpers for Prometheus labels, OpenTelemetry span attributes, and Sentry context without hard dependencies
+- **First-Party Metrics & Security Signals**: Optional logger health, pipeline, API timing, and detect-only security metrics with safe labels
 - **Policy Controls**: Optional endpoint-specific rules for logging, masking, payload stripping, and signal/export gating
 
 ### 🌐 Community & Support
@@ -252,6 +253,8 @@ API_LOGGER_SIGNAL.listen -= log_to_file
 - [Copy-paste setup recipes](docs/quickstart.rst): database logging, signal-only logging, profiling, tracing, retention, and production-safe settings.
 - [ASGI-native logging](docs/asgi.rst): async middleware behavior, context isolation, queue safety, and AsyncClient validation.
 - [Safe observability integrations](docs/observability_integrations.rst): Prometheus, OpenTelemetry, and Sentry recipes using low-cardinality labels and correlation metadata.
+- [First-party metrics](docs/metrics.rst): optional Prometheus recorder, logger overhead, queue health, API metrics, safe labels, and endpoint guidance.
+- [Security signals](docs/security_signals.rst): detect-only suspicious activity metrics, bounded body inspection, rule IDs, and false-positive guidance.
 - [Policy controls](docs/policy_controls.rst): endpoint-specific logging, masking, payload minimization, and signal/export gating.
 - [AI assistant guidance](docs/ai_readiness.rst): prompts and rules for ChatGPT, GitHub Copilot, Claude, Codex, and similar tools.
 - [Comparison and migration guide](docs/comparison_and_migration.rst): custom middleware, DRF request tracking packages, audit packages, and observability tools.
@@ -575,6 +578,100 @@ class, and method. Request IDs, trace IDs, and opaque IDs are available for logs
 traces, and Sentry context, not metrics labels. The helpers do not import
 Prometheus, OpenTelemetry, or Sentry; applications own those dependencies and
 exporter configuration.
+
+### First-Party Metrics & Security Signals
+
+Enable optional package-owned metrics when you want DRF API Logger to report its
+own overhead and background pipeline health:
+
+```bash
+pip install "drf-api-logger[prometheus]"
+```
+
+```python
+DRF_API_LOGGER_METRICS_ENABLED = True
+DRF_API_LOGGER_METRICS_GROUPS = ["logger", "pipeline"]
+```
+
+Logger and pipeline metrics include request-path overhead, payload capture,
+masking, serialization, enqueue duration, queue depth, queue utilization,
+worker up/down state, worker starts, flush duration, batch size, storage write
+duration, dropped/skipped logs, and storage write failures.
+
+API request metrics are disabled separately to avoid duplicate instrumentation:
+
+```python
+DRF_API_LOGGER_API_METRICS_ENABLED = True
+```
+
+API metrics include request count, duration, active requests, request and
+non-streaming response body sizes, slow-request counts, exception counts, and
+HTTP 429 throttle counts using normalized route labels.
+
+Profiling metrics are available when profiling data exists:
+
+```python
+DRF_API_LOGGER_ENABLE_PROFILING = True
+DRF_API_LOGGER_METRICS_GROUPS = ["logger", "pipeline", "profiling"]
+```
+
+They summarize SQL duration, query count, duplicate query count, likely N+1
+signals, view/serialization duration, and middleware duration without exposing
+SQL text as labels.
+
+These metrics support practical dashboards and alerts: watch queue depth and
+storage failures to protect log reliability, compare request overhead against
+API latency, find SQL-heavy or likely N+1 endpoints, and alert on suspicious
+security rule matches such as auth failures, route scans, payload attacks, and
+bulk export behavior. See [First-party metrics](docs/metrics.rst) for PromQL
+examples.
+
+Security signals are detect-only and disabled by default:
+
+```python
+DRF_API_LOGGER_SECURITY_METRICS_ENABLED = True
+DRF_API_LOGGER_SECURITY_MODE = "detect"
+DRF_API_LOGGER_SECURITY_BODY_INSPECTION = {
+    "enabled": True,
+    "max_body_bytes": 8192,
+    "inspect_request_body": True,
+    "inspect_response_body": False,
+}
+```
+
+Rules `DRFSEC-001` through `DRFSEC-016` cover authentication failures,
+success-after-failure patterns, token failures, authorization failures,
+admin/debug probes, payload attack patterns, rate-limit pressure, route scans,
+object ID enumeration hints, log injection, sensitive response-field hints,
+pagination sweeps, bulk exports, high response volume, sensitive business
+routes, and repeated business-flow actions. Correlation uses bounded
+process-local state and internal HMAC actor fingerprints, never metric labels.
+
+Metric labels are allowlisted and low-cardinality. Do not use raw URLs, query
+strings, request IDs, trace IDs, user IDs, IPs, object IDs, tokens, headers,
+request bodies, response bodies, SQL queries, or exception messages as labels.
+Unresolved 404 paths use fixed `route="unresolved"` and
+`view_name="unresolved"` labels instead of raw paths.
+
+The optional Prometheus endpoint is off by default:
+
+```python
+DRF_API_LOGGER_METRICS_PROMETHEUS_ENDPOINT_ENABLED = True
+```
+
+Mount it only under an internal protected path:
+
+```python
+from django.urls import include, path
+
+urlpatterns = [
+    path("internal/drf-api-logger/", include("drf_api_logger.metrics.urls")),
+]
+```
+
+Run `python manage.py check` after enabling metrics. The checks report missing
+Prometheus dependencies, unsafe labels, endpoint exposure warnings, and unsafe
+security body-inspection limits.
 
 ## 📊 Programmatic Access
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -34,6 +34,9 @@ python test_runner_simple.py
 # Full Django test suite
 python -m django test tests --settings=tests.test_settings --verbosity=1
 
+# Metrics and security signal tests
+python -m django test tests.test_metrics --settings=tests.test_settings --verbosity=2
+
 # Coverage
 coverage run --source=drf_api_logger -m django test tests --settings=tests.test_settings --verbosity=1
 coverage report
@@ -66,6 +69,7 @@ make check-package
 - `tests/test_signals.py`: event listeners, background queue behavior, app startup, and worker stats.
 - `tests/test_diagnostics.py`: production doctor checks for logging mode, database readiness, queue status, payload limits, masking, and profiling risk.
 - `tests/test_observability.py`: dependency-free Prometheus, OpenTelemetry, and Sentry helper behavior.
+- `tests/test_metrics.py`: optional metrics settings, safe labels, no-op recorder, system checks, middleware metrics hooks, queue metrics, security signals, and endpoint safety.
 - `tests/test_policy.py`: logging policy decisions, endpoint rules, callable overrides, extra mask keys, and safe failure behavior.
 - `tests/test_profiling.py`: profiling settings, SQL tracking, admin diagnosis, and nullable profiling fields.
 - `tests/test_backward_compat.py`: default behavior when profiling is disabled.
@@ -141,6 +145,7 @@ Monitor `queue_backlog`, `dropped_count`, and `failed_insert_count` in productio
 - Add or update tests for every behavior change.
 - Watch new tests fail before implementing behavior.
 - Observability integrations must keep optional third-party packages out of install requirements and must not export headers, bodies, secrets, or high-cardinality IDs as metrics labels.
+- First-party metrics must stay disabled by default, keep Prometheus optional, reject unsafe labels, and keep security signals detect-only.
 - Keep tests deterministic and isolated.
 - Clean up signal listeners in `finally` blocks.
 - Use real Django/DRF behavior where practical.

--- a/docs/DEVELOPER_TESTING.md
+++ b/docs/DEVELOPER_TESTING.md
@@ -18,6 +18,7 @@ python -m pip install -r requirements-dev.txt
 ```bash
 python test_runner_simple.py
 python -m django test tests --settings=tests.test_settings --verbosity=1
+python -m django test tests.test_metrics --settings=tests.test_settings --verbosity=2
 python -m django test tests.test_asgi_middleware --settings=tests.test_settings --verbosity=2
 coverage run --source=drf_api_logger -m django test tests --settings=tests.test_settings --verbosity=1
 coverage report
@@ -60,6 +61,9 @@ This matrix is representative coverage, not the complete Django 4.2+ support lis
 - ASGI middleware behavior through direct async calls and Django `AsyncClient`.
 - Sensitive data masking for bodies, headers, responses, and URL query parameters.
 - Signal listener behavior and failure isolation.
+- First-party metrics settings, safe labels, optional Prometheus dependency,
+  system checks, middleware hooks, queue metrics, detect-only security signals,
+  and endpoint safety.
 - Background queue flushing, stats, shutdown, and database alias handling.
 - Admin display, filters, export, and profiling diagnosis.
 - Management commands such as `prune_api_logs`.

--- a/docs/compliance.rst
+++ b/docs/compliance.rst
@@ -93,6 +93,26 @@ When exporting DRF API Logger signal data to observability systems:
 - Use Sentry context for debugging metadata, not payload storage.
 - Keep external exporter credentials outside DRF API Logger settings.
 
+Metrics and Security Signal Controls
+------------------------------------
+
+First-party metrics and security signals are disabled by default. When enabled,
+they are designed for low-cardinality operational aggregates, not payload or
+identity storage.
+
+For compliance-sensitive deployments:
+
+- Keep request IDs, trace IDs, user IDs, tenant IDs, IP addresses, object IDs,
+  raw URLs, query strings, headers, cookies, tokens, SQL queries, request
+  bodies, response bodies, and exception messages out of metric labels.
+- Use route patterns, URL names, method, and status class for metrics labels.
+- Keep the optional Prometheus endpoint internal-only and protected.
+- Keep security signals in detect-only mode.
+- Keep response-body inspection disabled unless there is a documented
+  operational need.
+- Keep request-body inspection bounded with a finite
+  ``DRF_API_LOGGER_SECURITY_BODY_INSPECTION["max_body_bytes"]`` value.
+
 Policy Controls
 ---------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'DRF API Logger'
 copyright = '2020, Vishal Anand'
 author = 'Vishal Anand'
-release = '1.3.0'
+release = '1.4.0'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/docs/developer_testing.rst
+++ b/docs/developer_testing.rst
@@ -41,6 +41,12 @@ Run the full Django suite:
 
    python -m django test tests --settings=tests.test_settings --verbosity=1
 
+Run the metrics and security signal tests:
+
+.. code-block:: bash
+
+   python -m django test tests.test_metrics --settings=tests.test_settings --verbosity=2
+
 Run coverage:
 
 .. code-block:: bash
@@ -87,6 +93,9 @@ Add or update tests for every behavior change. Cover the touched surface:
 - Observability helper behavior for Prometheus labels, OpenTelemetry span
   attributes, Sentry context, optional dependency safety, and high-cardinality
   label prevention.
+- First-party metrics behavior for safe labels, optional Prometheus dependency,
+  no-op disabled mode, system checks, middleware hooks, queue metrics, security
+  signals, and internal endpoint safety.
 - Policy gate behavior for full log drops, metadata-only logging, extra mask
   keys, signal/export gating, safe failures, and default backward compatibility.
 - Production diagnostics and doctor command behavior, including JSON output,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 DRF API Logger
 ==============
 
-.. image:: https://img.shields.io/badge/version-1.3.0-blue.svg
+.. image:: https://img.shields.io/badge/version-1.4.0-blue.svg
    :alt: Version
 .. image:: https://static.pepy.tech/personalized-badge/drf-api-logger?period=total&units=none&left_color=black&right_color=orange&left_text=Downloads%20Total
    :target: http://pepy.tech/project/drf-api-logger
@@ -25,6 +25,8 @@ profile SQL-heavy endpoints when enabled.
    quickstart
    asgi
    observability_integrations
+   metrics
+   security_signals
    policy_controls
    ai_readiness
    comparison_and_migration
@@ -46,6 +48,8 @@ Key Features
 - Per-request API profiling with auto-diagnosis of bottlenecks
 - Request correlation through request attributes, logging context, and signals
 - Optional Prometheus, OpenTelemetry, and Sentry helper functions with safe defaults
+- Optional first-party metrics for logger health, pipeline behavior, API timing,
+  and detect-only security signals
 - Optional endpoint-specific policy controls for logging, masking, payload
   stripping, and signal/export gating
 
@@ -385,6 +389,26 @@ Configuration Reference
      - str
      - ``None``
      - Dotted-path function to transform or drop log entries before queueing
+   * - ``DRF_API_LOGGER_METRICS_ENABLED``
+     - bool
+     - ``False``
+     - Enable optional first-party metrics recorder
+   * - ``DRF_API_LOGGER_METRICS_EXPORTER``
+     - str
+     - ``'prometheus'``
+     - Metrics exporter: ``'prometheus'`` or ``'none'``
+   * - ``DRF_API_LOGGER_API_METRICS_ENABLED``
+     - bool
+     - ``False``
+     - Enable API request count and duration metrics
+   * - ``DRF_API_LOGGER_SECURITY_METRICS_ENABLED``
+     - bool
+     - ``False``
+     - Enable detect-only suspicious activity metrics
+   * - ``DRF_API_LOGGER_METRICS_PROMETHEUS_ENDPOINT_ENABLED``
+     - bool
+     - ``False``
+     - Enable optional internal Prometheus exposition view
 
 .. note::
 

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -1,0 +1,309 @@
+Metrics
+=============
+
+DRF API Logger can expose optional first-party metrics for logger health,
+background pipeline behavior, API request timing, and security-signal counts.
+The feature is disabled by default and does not add database migrations.
+
+Metrics are designed for Prometheus-style systems while preserving the package
+privacy model:
+
+- no request bodies, response bodies, headers, cookies, tokens, raw URLs, query
+  strings, request IDs, trace IDs, user IDs, IPs, object IDs, SQL queries, or
+  exception messages are used as metric labels;
+- route labels come from Django's resolved route pattern or safe resolver
+  metadata, not ``request.path``;
+- requests that do not resolve to a Django route use fixed
+  ``route="unresolved"`` and ``view_name="unresolved"`` labels instead of raw
+  404 paths;
+- all recorder calls collapse to a no-op when metrics are disabled or the
+  exporter is unavailable.
+
+Installation
+------------
+
+Prometheus support is optional:
+
+.. code-block:: bash
+
+   pip install "drf-api-logger[prometheus]"
+
+Without the extra, the package still imports and normal API logging continues
+to work. If Prometheus metrics are enabled without ``prometheus_client``, Django
+system checks report a configuration error.
+
+Logger and Pipeline Metrics
+---------------------------
+
+Start with logger and pipeline metrics. These show whether DRF API Logger itself
+is adding overhead or falling behind:
+
+.. code-block:: python
+
+   DRF_API_LOGGER_METRICS_ENABLED = True
+   DRF_API_LOGGER_METRICS_EXPORTER = "prometheus"
+   DRF_API_LOGGER_METRICS_GROUPS = ["logger", "pipeline"]
+
+Useful signals include:
+
+- request-path logger overhead;
+- payload capture, masking, serialization, and enqueue duration;
+- log events enqueued, processed, skipped, or dropped;
+- queue backlog;
+- configured queue batch threshold;
+- queue utilization ratio;
+- worker up/down state;
+- worker starts observed in the current process;
+- batch flush duration and batch size;
+- storage write duration;
+- storage write failures.
+
+``DRF_LOGGER_QUEUE_MAX_SIZE`` remains the bulk insert batch threshold. It is not
+a hard queue capacity; the queue is intentionally unbounded so request threads
+do not block on database pressure. Metrics expose backlog and batch threshold
+so operators can alert when backlog grows continuously.
+
+API Metrics
+-----------
+
+Enable API-level request metrics only when the application does not already
+collect equivalent Django/OpenTelemetry HTTP server metrics:
+
+.. code-block:: python
+
+   DRF_API_LOGGER_METRICS_ENABLED = True
+   DRF_API_LOGGER_API_METRICS_ENABLED = True
+
+API metrics can observe requests even when ``DRF_API_LOGGER_DATABASE`` and
+``DRF_API_LOGGER_SIGNAL`` are disabled. This mode records safe timing and route
+metadata only; it does not build database log payloads or emit
+``API_LOGGER_SIGNAL``.
+
+API metrics include:
+
+- request count and duration;
+- active in-flight requests;
+- request body size from ``Content-Length`` when available;
+- non-streaming response body size without force-reading streaming responses;
+- slow-request counts using ``DRF_API_LOGGER_SLOW_API_ABOVE``;
+- exception counts by safe exception class;
+- throttle counts for HTTP 429 responses.
+
+Profiling Metrics
+-----------------
+
+Profiling metrics are emitted only when profiling is enabled and profiling data
+exists:
+
+.. code-block:: python
+
+   DRF_API_LOGGER_ENABLE_PROFILING = True
+   DRF_API_LOGGER_METRICS_ENABLED = True
+   DRF_API_LOGGER_METRICS_GROUPS = ["logger", "pipeline", "profiling"]
+
+These metrics expose SQL duration, query count, duplicate query count, likely
+N+1 signals, view/serialization duration, and middleware timing. They summarize
+the existing profiling payload and never expose SQL text as labels.
+
+What You Can Do With These Metrics
+----------------------------------
+
+These metrics are most useful when they answer operational questions that are
+hard to answer from individual log rows alone.
+
+Protect API logging reliability
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use queue, worker, and storage metrics to detect when logging is falling behind
+before API log rows are lost or delayed:
+
+.. code-block:: text
+
+   drf_api_logger_queue_depth{queue_name="database"}
+
+.. code-block:: text
+
+   rate(drf_api_logger_log_events_dropped_total[5m])
+
+.. code-block:: text
+
+   rate(drf_api_logger_storage_write_failures_total[5m])
+
+These signals help answer questions such as:
+
+- Is the background worker alive?
+- Is the database insert pipeline falling behind traffic?
+- Are logs being skipped by policy or dropped by a handler?
+- Did a migration or database outage break log persistence?
+
+Measure logger overhead
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Track whether logging, masking, serialization, or enqueueing has become a
+meaningful part of request latency:
+
+.. code-block:: text
+
+   histogram_quantile(
+     0.95,
+     sum by (le, route) (
+       rate(drf_api_logger_request_overhead_seconds_bucket[5m])
+     )
+   )
+
+If this increases for a route, compare it with payload capture and masking
+duration:
+
+.. code-block:: text
+
+   histogram_quantile(
+     0.95,
+     sum by (le, location) (
+       rate(drf_api_logger_payload_capture_duration_seconds_bucket[5m])
+     )
+   )
+
+This helps decide whether a large response body, expensive masking, or queue
+pressure is responsible.
+
+Find slow or SQL-heavy endpoints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+API and profiling metrics highlight endpoints that are slow because of view
+work, SQL work, or repeated queries:
+
+.. code-block:: text
+
+   histogram_quantile(
+     0.95,
+     sum by (le, route) (
+       rate(drf_api_logger_http_request_duration_seconds_bucket[5m])
+     )
+   )
+
+Average SQL query count by route:
+
+.. code-block:: text
+
+   sum by (route) (rate(drf_api_logger_request_sql_queries_sum[5m]))
+   /
+   sum by (route) (rate(drf_api_logger_request_sql_queries_count[5m]))
+
+Likely N+1 query signals:
+
+.. code-block:: text
+
+   rate(drf_api_logger_n_plus_one_suspected_total[15m])
+
+These are useful for prioritizing endpoint tuning and confirming that a fix
+actually reduced query count or view duration.
+
+Spot abuse and suspicious activity
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Security metrics are detect-only. They do not block requests, but they give
+operators low-cardinality counters for suspicious patterns:
+
+.. code-block:: text
+
+   sum by (rule_id, route) (
+     rate(drf_api_logger_security_rule_matches_total[5m])
+   )
+
+Examples:
+
+- authentication abuse: ``DRFSEC-001`` and ``DRFSEC-002``;
+- token failure bursts: ``DRFSEC-003``;
+- route scans and unresolved 404 noise: ``DRFSEC-008`` with
+  ``route="unresolved"``;
+- object ID enumeration hints: ``DRFSEC-009``;
+- SQLi, XSS, path traversal, or log-injection payload patterns:
+  ``DRFSEC-006`` and ``DRFSEC-010``;
+- export or high-volume response behavior: ``DRFSEC-013`` and
+  ``DRFSEC-014``.
+
+For example, to alert on warning-level security activity:
+
+.. code-block:: text
+
+   sum by (category, severity, route) (
+     rate(drf_api_logger_security_alerts_total[5m])
+   )
+
+Keep dashboards safe by design
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All examples above use route patterns, status buckets, rule IDs, categories, and
+other bounded values. Avoid raw paths, IDs, IPs, request bodies, response bodies,
+SQL text, and exception messages in dashboards and alerts. Use masked log rows,
+trace context, or Sentry for per-request investigation.
+
+Safe Labels
+-----------
+
+Default labels:
+
+.. code-block:: python
+
+   DRF_API_LOGGER_METRICS_LABELS = [
+       "method",
+       "route",
+       "view_name",
+       "status_class",
+   ]
+
+Do not configure high-cardinality or sensitive labels. System checks reject
+unsafe labels such as ``request_id``, ``trace_id``, ``user_id``, ``client_ip``,
+``raw_path``, ``query_string``, ``token``, ``object_id``, ``request_body``, and
+``response_body``.
+
+Prometheus Endpoint
+-------------------
+
+DRF API Logger can provide an optional endpoint, but it is disabled by default.
+Expose it only on an internal path protected by your network, gateway, service
+mesh, or authentication layer:
+
+.. code-block:: python
+
+   DRF_API_LOGGER_METRICS_PROMETHEUS_ENDPOINT_ENABLED = True
+
+Add it under an internal prefix:
+
+.. code-block:: python
+
+   from django.urls import include, path
+
+   urlpatterns = [
+       path("internal/drf-api-logger/", include("drf_api_logger.metrics.urls")),
+   ]
+
+The default included path is ``metrics/``, producing
+``/internal/drf-api-logger/metrics/`` in the example above. Do not expose this
+endpoint publicly; it can reveal route names, latency distributions, error
+rates, worker health, and security signal counts.
+
+System Checks
+-------------
+
+Run Django checks after enabling metrics:
+
+.. code-block:: bash
+
+   python manage.py check
+
+Checks validate missing Prometheus dependencies, unsafe labels, endpoint
+exposure warnings, and unsafe security body-inspection limits.
+
+Operations Notes
+----------------
+
+- Keep API metrics disabled when another HTTP metrics instrumenter already
+  records request count and duration.
+- Prefer logger and pipeline metrics first; they are specific to DRF API Logger.
+- In Gunicorn or uWSGI multi-process deployments, configure Prometheus
+  multiprocess support according to ``prometheus_client`` documentation.
+- Alert on growing queue backlog, dropped logs, failed writes, and worker down
+  state.
+- Treat metrics as operational aggregates, not investigation evidence. Use
+  masked logs, traces, or Sentry context for per-request debugging.

--- a/docs/observability_integrations.rst
+++ b/docs/observability_integrations.rst
@@ -2,9 +2,14 @@ Safe Observability Integrations
 ===============================
 
 DRF API Logger can feed metrics, traces, and error context through signal
-listeners. The package does not start exporters, expose a metrics endpoint, or
-send data to external systems by itself. Applications own their Prometheus,
-OpenTelemetry, Sentry, Loki, Elasticsearch, or hosted monitoring setup.
+listeners. By default, the package does not start exporters, expose a metrics
+endpoint, or send data to external systems by itself. Applications own their
+Prometheus, OpenTelemetry, Sentry, Loki, Elasticsearch, or hosted monitoring
+setup.
+
+For teams that want package-owned logger health and pipeline metrics, DRF API
+Logger also includes an optional first-party Prometheus recorder and internal
+metrics endpoint. See :doc:`metrics` for that opt-in path.
 
 Prerequisites
 -------------
@@ -120,6 +125,8 @@ Safety Rules
 - Keep payloads, headers, cookies, authorization values, and direct identities
   out of observability exports.
 - Keep exporter ownership in the application, not in DRF API Logger.
+- If using the first-party metrics endpoint, expose it only on an internal
+  protected path.
 - Prefer route patterns and URL names over raw URLs.
 - Use ``DRF_API_LOGGER_SKIP_URL_NAME`` or ``DRF_API_LOGGER_SKIP_NAMESPACE`` to
   avoid recording health checks, metrics endpoints, admin paths, and noisy

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -7,7 +7,7 @@ retention, and health checks.
 Supported Runtime Matrix
 ------------------------
 
-DRF API Logger 1.3.0 supports:
+DRF API Logger 1.4.0 supports:
 
 - Python 3.10+
 - Django 4.2+
@@ -212,6 +212,49 @@ Recommended operating pattern:
 - Keep request and response payloads out of metrics, traces, and Sentry context.
 - Skip health checks and metrics endpoints with ``DRF_API_LOGGER_SKIP_URL_NAME``
   or ``DRF_API_LOGGER_SKIP_NAMESPACE``.
+
+First-Party Metrics Operations
+------------------------------
+
+The optional first-party metrics recorder is disabled by default. Enable it when
+the application wants DRF API Logger to report its own overhead and background
+pipeline health:
+
+.. code-block:: python
+
+   DRF_API_LOGGER_METRICS_ENABLED = True
+   DRF_API_LOGGER_METRICS_GROUPS = ["logger", "pipeline"]
+
+Prefer logger and pipeline metrics first. These show request-path overhead,
+payload capture and masking duration, queue backlog, queue utilization, dropped
+logs, processed logs, worker state, worker starts, flush duration, batch size,
+storage write duration, and storage write failures.
+
+Enable API metrics only when another Django or OpenTelemetry instrumenter is
+not already recording HTTP request count and duration:
+
+.. code-block:: python
+
+   DRF_API_LOGGER_API_METRICS_ENABLED = True
+
+If the optional Prometheus endpoint is enabled, mount it under an internal
+prefix and protect it at the network or authentication layer:
+
+.. code-block:: python
+
+   DRF_API_LOGGER_METRICS_PROMETHEUS_ENDPOINT_ENABLED = True
+
+The endpoint can reveal route names, latency distributions, error rates, queue
+health, and security signal counts. Do not expose it publicly.
+
+API metrics also expose active requests, request body size from
+``Content-Length``, non-streaming response body size, slow-request counts,
+exception counts, and HTTP 429 throttle counts. Keep them off when another
+instrumenter already owns HTTP server metrics.
+
+``DRF_LOGGER_QUEUE_MAX_SIZE`` remains a bulk insert batch threshold, not a hard
+queue capacity. Alert on backlog that grows continuously rather than treating
+the batch threshold as a maximum queue size.
 
 ASGI Operations
 ---------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -196,6 +196,38 @@ Prometheus labels are limited to route, URL name, app name, namespace, status
 class, and method. Request IDs and trace IDs are available for logs, traces, and
 Sentry context, not metrics labels.
 
+First-Party Logger Metrics
+--------------------------
+
+Use optional first-party metrics when the application wants DRF API Logger to
+report its own request-path overhead and background pipeline health:
+
+.. code-block:: bash
+
+   pip install "drf-api-logger[prometheus]"
+
+.. code-block:: python
+
+   DRF_API_LOGGER_METRICS_ENABLED = True
+   DRF_API_LOGGER_METRICS_GROUPS = ["logger", "pipeline"]
+
+API request metrics are separate and disabled by default to avoid duplicate
+instrumentation with Django, OpenTelemetry, or other HTTP metrics middleware:
+
+.. code-block:: python
+
+   DRF_API_LOGGER_API_METRICS_ENABLED = True
+
+Logger and pipeline metrics cover overhead, payload capture, masking,
+serialization, enqueue duration, queue depth/utilization, worker state, flush
+duration, storage write duration/failures, and dropped or skipped logs. API
+metrics add request count, duration, active requests, body-size histograms,
+slow-request counts, exception counts, and HTTP 429 throttle counts. Add the
+``profiling`` metrics group only when ``DRF_API_LOGGER_ENABLE_PROFILING`` is
+enabled and SQL/view/middleware summaries are useful.
+
+See :doc:`metrics` for endpoint setup, safe labels, and Prometheus operations.
+
 ASGI-Native Logging
 -------------------
 

--- a/docs/security_signals.rst
+++ b/docs/security_signals.rst
@@ -1,0 +1,127 @@
+Security Signals
+================
+
+DRF API Logger can emit optional, detect-only security metrics for suspicious
+API activity. Security signals are disabled by default and do not block
+requests.
+
+The feature is not a WAF, IDS, SIEM, API gateway, rate limiter, or fraud engine.
+It provides privacy-safe API-level signals that can feed systems your team
+already operates.
+
+Enable Detect-Only Signals
+--------------------------
+
+.. code-block:: python
+
+   DRF_API_LOGGER_METRICS_ENABLED = True
+   DRF_API_LOGGER_SECURITY_METRICS_ENABLED = True
+   DRF_API_LOGGER_SECURITY_MODE = "detect"
+
+Only ``detect`` mode is supported. Detection errors are isolated and must not
+break customer API responses.
+
+Body Inspection
+---------------
+
+Payload inspection is bounded. The default request sample limit is 8192 bytes,
+and response-body inspection is off:
+
+.. code-block:: python
+
+   DRF_API_LOGGER_SECURITY_BODY_INSPECTION = {
+       "enabled": True,
+       "max_body_bytes": 8192,
+       "inspect_request_body": True,
+       "inspect_response_body": False,
+   }
+
+Security signals never place sampled body content in metric labels or signal
+objects. Samples are used only inside the request path for bounded pattern
+matching.
+
+Rule Coverage
+-------------
+
+The implementation registers rule IDs ``DRFSEC-001`` through ``DRFSEC-016``.
+Rules are low-cost and detect-only. Some rules are stateless, and correlation
+rules use bounded in-memory TTL state per process:
+
+- authentication failures;
+- success after repeated authentication failures;
+- token/auth endpoint failures;
+- authorization failures;
+- admin/debug probing;
+- suspicious payload patterns;
+- rate-limit pressure;
+- route scanning hints;
+- object ID enumeration hints;
+- log injection control characters;
+- suspected sensitive field exposure in response samples when response
+  inspection is explicitly enabled;
+- pagination sweep hints;
+- bulk export hints;
+- high response volume hints;
+- customer-provided sensitive-route context.
+- repeated customer-provided business-flow actions.
+
+Actor correlation uses an internal HMAC fingerprint derived from configured
+actor signals such as authenticated user id, IP address, or user-agent family.
+The fingerprint is used only inside the process-local rolling state and is not
+emitted as a metric label.
+
+Business Context Hook
+---------------------
+
+Applications can provide safe, low-cardinality business context:
+
+.. code-block:: python
+
+   DRF_API_LOGGER_SECURITY_CONTEXT_GETTER = "myapp.security.get_context"
+
+The callable receives ``request``, ``response``, and ``exception`` keyword
+arguments and may return keys such as ``actor_type``, ``business_action``,
+``resource_type``, ``flow_name``, and ``is_sensitive_route``. Values are
+sanitized before rule evaluation. Do not return raw user IDs, object IDs,
+tenant IDs, emails, tokens, or payload content.
+
+Safe Labels
+-----------
+
+Security metrics use only low-cardinality labels:
+
+- ``rule_id``
+- ``event_type``
+- ``category``
+- ``severity``
+- ``route``
+- ``method``
+- ``status_class``
+- ``outcome``
+
+Raw users, IPs, object IDs, tokens, request IDs, trace IDs, request bodies,
+response bodies, exception messages, and SQL queries are never labels.
+
+False Positives
+---------------
+
+Security signals are probabilistic. Treat them as triage and dashboard inputs,
+not as proof of an attack. Tune alerts by route, severity, and sustained rate,
+and investigate with your normal logs, traces, SIEM, WAF, gateway, or incident
+workflow.
+
+Operational Pattern
+-------------------
+
+Start conservatively:
+
+1. Enable logger and pipeline metrics.
+2. Enable security metrics in a non-production environment.
+3. Review rule counts and false positives.
+4. Enable bounded request-body inspection only where acceptable.
+5. Keep blocking, enforcement, and incident response in dedicated security
+   tooling.
+
+For regulated environments, keep response inspection disabled unless there is a
+documented operational need and the sampled content is covered by your privacy
+and retention policy.

--- a/drf_api_logger/apps.py
+++ b/drf_api_logger/apps.py
@@ -24,6 +24,7 @@ class LoggerConfig(AppConfig):
         but only in the main process (to avoid duplication on autoreload).
         """
         global LOGGER_THREAD
+        from drf_api_logger.metrics import system_checks  # noqa: F401
 
         # Check if we should start the logger thread
         # In development with Django's runserver, RUN_MAIN prevents duplicate threads

--- a/drf_api_logger/insert_log_into_database.py
+++ b/drf_api_logger/insert_log_into_database.py
@@ -1,10 +1,12 @@
 import atexit
 import signal
+import time
 from queue import Empty, Queue
 from importlib import import_module
 from django.conf import settings
 from threading import Thread, Event, Lock
 from django.db.utils import OperationalError
+from drf_api_logger.metrics.recorder import get_recorder
 from drf_api_logger.models import APILogsModel
 
 
@@ -76,6 +78,13 @@ class InsertLogIntoDatabase(Thread):
         if not self._atexit_registered:
             atexit.register(self.shutdown)
             self._atexit_registered = True
+        try:
+            recorder = get_recorder()
+            recorder.increment_worker_restart(self.name or 'insert_log_into_database')
+            recorder.set_worker_up(self.name or 'insert_log_into_database', True)
+            self._record_queue_metrics(recorder)
+        except Exception:
+            pass
         self.start_queue_process()
 
     def put_log_data(self, data):
@@ -90,14 +99,37 @@ class InsertLogIntoDatabase(Thread):
             data = self.custom_handler(data)
             if data is None:
                 self._increment_stat('_dropped_count')
+                try:
+                    recorder = get_recorder()
+                    recorder.increment_dropped_logs('custom_handler')
+                    self._record_queue_metrics(recorder)
+                except Exception:
+                    pass
                 return
 
+        enqueue_start = time.perf_counter()
         try:
             self._queue.put_nowait(APILogsModel(**data))
         except Exception as e:
             self._increment_stat('_dropped_count')
+            try:
+                recorder = get_recorder()
+                recorder.increment_dropped_logs('queue_error')
+                self._record_queue_metrics(recorder)
+            except Exception:
+                pass
             print('DRF API LOGGER EXCEPTION:', e)
             return
+        finally:
+            enqueue_duration = time.perf_counter() - enqueue_start
+
+        try:
+            recorder = get_recorder()
+            recorder.observe_enqueue({'queue_name': 'database'}, enqueue_duration)
+            recorder.increment_enqueued_logs('database')
+            self._record_queue_metrics(recorder)
+        except Exception:
+            pass
 
         # If queue reaches the batch threshold, wake the worker to flush.
         if self._queue.qsize() >= self.DRF_LOGGER_QUEUE_MAX_SIZE:
@@ -140,11 +172,26 @@ class InsertLogIntoDatabase(Thread):
         Raises:
             Exception: If the model doesn't exist or another database error occurs.
         """
+        flush_start = time.perf_counter()
         try:
             APILogsModel.objects.using(self.DRF_API_LOGGER_DEFAULT_DATABASE).bulk_create(bulk_item)
             self._increment_stat('_inserted_count', len(bulk_item))
+            try:
+                recorder = get_recorder()
+                recorder.increment_processed_logs('database', len(bulk_item))
+                recorder.observe_flush('database', time.perf_counter() - flush_start, len(bulk_item))
+                recorder.observe_storage_write('database', time.perf_counter() - flush_start)
+                self._record_queue_metrics(recorder)
+            except Exception:
+                pass
         except OperationalError:
             self._increment_stat('_failed_insert_count', len(bulk_item))
+            try:
+                recorder = get_recorder()
+                recorder.increment_storage_write_failure('database', 'OperationalError')
+                recorder.observe_storage_write('database', time.perf_counter() - flush_start)
+            except Exception:
+                pass
             raise Exception("""
             DRF API LOGGER EXCEPTION
             Model does not exist.
@@ -152,6 +199,12 @@ class InsertLogIntoDatabase(Thread):
             """)
         except Exception as e:
             self._increment_stat('_failed_insert_count', len(bulk_item))
+            try:
+                recorder = get_recorder()
+                recorder.increment_storage_write_failure('database', e.__class__.__name__)
+                recorder.observe_storage_write('database', time.perf_counter() - flush_start)
+            except Exception:
+                pass
             # Logs other unexpected exceptions to the console
             print('DRF API LOGGER EXCEPTION:', e)
 
@@ -182,6 +235,10 @@ class InsertLogIntoDatabase(Thread):
         self._stop_event.set()
         self._flush_event.set()
         self._start_bulk_insertion()
+        try:
+            get_recorder().set_worker_up(self.name or 'insert_log_into_database', False)
+        except Exception:
+            pass
 
     def get_status(self):
         """
@@ -200,3 +257,10 @@ class InsertLogIntoDatabase(Thread):
     def _increment_stat(self, name, amount=1):
         with self._stats_lock:
             setattr(self, name, getattr(self, name) + amount)
+
+    def _record_queue_metrics(self, recorder):
+        depth = self._queue.qsize()
+        capacity = self.DRF_LOGGER_QUEUE_MAX_SIZE
+        recorder.set_queue_depth('database', depth)
+        recorder.set_queue_capacity('database', capacity)
+        recorder.set_queue_utilization('database', depth / capacity if capacity else 0)

--- a/drf_api_logger/metrics/__init__.py
+++ b/drf_api_logger/metrics/__init__.py
@@ -1,0 +1,3 @@
+"""Optional metrics and security signal support for DRF API Logger."""
+
+default_app_config = "drf_api_logger.apps.LoggerConfig"

--- a/drf_api_logger/metrics/labels.py
+++ b/drf_api_logger/metrics/labels.py
@@ -1,0 +1,157 @@
+import re
+
+from drf_api_logger.metrics import settings as metrics_settings
+
+
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+SAFE_ENUM_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,64}$")
+UNRESOLVED_ROUTE_LABEL = "unresolved"
+UNRESOLVED_VIEW_LABEL = "unresolved"
+
+
+def _safe_text(value, max_length=None):
+    if value is None:
+        return None
+    max_length = max_length or metrics_settings.max_label_length()
+    value = str(value).strip()
+    if not value or len(value) > max_length:
+        return None
+    if CONTROL_CHAR_RE.search(value):
+        return None
+    return value
+
+
+def _safe_label_value(value):
+    return _safe_text(value) or metrics_settings.UNKNOWN_LABEL_VALUE
+
+
+def _safe_enum_value(value):
+    value = _safe_text(value, max_length=64)
+    if not value or not SAFE_ENUM_RE.match(value):
+        return metrics_settings.UNKNOWN_LABEL_VALUE
+    return value
+
+
+def _safe_method(value):
+    value = _safe_text(value, max_length=16)
+    if not value:
+        return metrics_settings.UNKNOWN_LABEL_VALUE
+    value = value.upper()
+    if not SAFE_ENUM_RE.match(value):
+        return metrics_settings.UNKNOWN_LABEL_VALUE
+    return value
+
+
+def status_class(status_code):
+    try:
+        status_code = int(status_code)
+    except (TypeError, ValueError):
+        return metrics_settings.UNKNOWN_LABEL_VALUE
+    if status_code < 100 or status_code > 599:
+        return metrics_settings.UNKNOWN_LABEL_VALUE
+    return "{}xx".format(status_code // 100)
+
+
+def _view_name(resolver_match):
+    if resolver_match is None:
+        return None
+    view_func = getattr(resolver_match, "func", None)
+    view_class = getattr(view_func, "view_class", None)
+    class_module = getattr(view_class, "__module__", None)
+    class_name = getattr(view_class, "__name__", None)
+    if type(class_module) is str and type(class_name) is str:
+        return "{}.{}".format(class_module, class_name)
+
+    func_module = getattr(view_func, "__module__", None)
+    func_name = getattr(view_func, "__name__", None)
+    if type(func_module) is str and type(func_name) is str:
+        return "{}.{}".format(func_module, func_name)
+    return None
+
+
+def build_low_cardinality_from_resolver(resolver_match, status_code=None):
+    if resolver_match is None:
+        return {
+            "route": UNRESOLVED_ROUTE_LABEL,
+            "view_name": UNRESOLVED_VIEW_LABEL,
+            "status_class": status_class(status_code),
+        }
+    values = {
+        "route": getattr(resolver_match, "route", None),
+        "view_name": _view_name(resolver_match),
+        "app_name": getattr(resolver_match, "app_name", None),
+        "namespace": getattr(resolver_match, "namespace", None),
+        "url_name": getattr(resolver_match, "url_name", None),
+        "status_class": status_class(status_code),
+    }
+    return {
+        key: _safe_label_value(value)
+        for key, value in values.items()
+        if _safe_text(value) or key == "status_class"
+    }
+
+
+def _event_low_cardinality(event):
+    value = event.get("low_cardinality", {})
+    return value if type(value) is dict else {}
+
+
+def build_http_labels(event):
+    low_cardinality = _event_low_cardinality(event)
+    labels = {}
+    for key in metrics_settings.metric_label_keys():
+        if key == "method":
+            labels[key] = _safe_method(event.get("method"))
+        elif key == "status_code":
+            labels[key] = _safe_label_value(event.get("status_code"))
+        elif key == "status_class":
+            labels[key] = _safe_label_value(
+                low_cardinality.get("status_class")
+                or event.get("status_class")
+                or status_class(event.get("status_code"))
+            )
+        elif key == "route":
+            labels[key] = _safe_label_value(low_cardinality.get("route") or event.get("route"))
+        elif key in metrics_settings.ALLOWED_LABELS:
+            labels[key] = _safe_label_value(low_cardinality.get(key) or event.get(key))
+    return labels
+
+
+def build_http_core_labels(event):
+    low_cardinality = _event_low_cardinality(event)
+    return {
+        "method": _safe_method(event.get("method")),
+        "route": _safe_label_value(low_cardinality.get("route") or event.get("route")),
+        "view_name": _safe_label_value(low_cardinality.get("view_name") or event.get("view_name")),
+        "status_code": _safe_label_value(event.get("status_code")),
+        "status_class": _safe_label_value(
+            low_cardinality.get("status_class")
+            or event.get("status_class")
+            or status_class(event.get("status_code"))
+        ),
+        "exception_class": _safe_enum_value(event.get("exception_class")),
+        "throttle_scope": _safe_enum_value(event.get("throttle_scope")),
+    }
+
+
+def build_logger_labels(labels=None):
+    labels = labels or {}
+    safe = {}
+    for key, value in labels.items():
+        if key in metrics_settings.ALLOWED_LABELS and key not in metrics_settings.FORBIDDEN_LABELS:
+            safe[key] = _safe_label_value(value)
+    return safe
+
+
+def build_security_labels(signal):
+    return {
+        "event_type": _safe_enum_value(signal.event_type),
+        "category": _safe_enum_value(signal.category),
+        "severity": _safe_enum_value(signal.severity),
+        "rule_id": _safe_enum_value(signal.rule_id),
+        "route": _safe_label_value(signal.route),
+        "method": _safe_method(signal.method),
+        "status_class": _safe_enum_value(signal.status_class),
+        "outcome": _safe_enum_value(signal.outcome),
+        "reason": _safe_enum_value(signal.reason),
+    }

--- a/drf_api_logger/metrics/noop.py
+++ b/drf_api_logger/metrics/noop.py
@@ -1,0 +1,86 @@
+class NoOpTimer:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class NoOpMetricsRecorder:
+    def timer(self, name, labels=None):
+        return NoOpTimer()
+
+    def observe_http_request(self, event):
+        return None
+
+    def increment_active_requests(self, labels):
+        return None
+
+    def decrement_active_requests(self, labels):
+        return None
+
+    def increment_http_exception(self, event):
+        return None
+
+    def observe_logger_overhead(self, labels, duration_seconds):
+        return None
+
+    def observe_payload_capture(self, labels, location, duration_seconds):
+        return None
+
+    def observe_masking(self, labels, location, duration_seconds):
+        return None
+
+    def observe_serialization(self, labels, duration_seconds):
+        return None
+
+    def observe_enqueue(self, labels, duration_seconds):
+        return None
+
+    def increment_enqueued_logs(self, queue_name="default"):
+        return None
+
+    def increment_processed_logs(self, storage_backend, count):
+        return None
+
+    def increment_dropped_logs(self, reason):
+        return None
+
+    def increment_skipped_logs(self, reason):
+        return None
+
+    def increment_storage_write_failure(self, storage_backend, exception_class):
+        return None
+
+    def set_queue_depth(self, queue_name, depth):
+        return None
+
+    def set_queue_capacity(self, queue_name, capacity):
+        return None
+
+    def set_queue_utilization(self, queue_name, ratio):
+        return None
+
+    def set_worker_up(self, worker_name, up):
+        return None
+
+    def increment_worker_restart(self, worker_name):
+        return None
+
+    def observe_flush(self, storage_backend, duration_seconds, batch_size):
+        return None
+
+    def observe_storage_write(self, storage_backend, duration_seconds):
+        return None
+
+    def observe_profiling(self, labels, profiling):
+        return None
+
+    def observe_security_event(self, signal):
+        return None
+
+    def observe_security_detection(self, labels, duration_seconds):
+        return None
+
+    def increment_security_detection_error(self, rule_id, exception_class):
+        return None

--- a/drf_api_logger/metrics/prometheus.py
+++ b/drf_api_logger/metrics/prometheus.py
@@ -1,0 +1,648 @@
+from drf_api_logger.metrics import settings as metrics_settings
+from drf_api_logger.metrics.labels import (
+    build_http_labels,
+    build_http_core_labels,
+    build_logger_labels,
+    build_security_labels,
+)
+from drf_api_logger.metrics.recorder import TimerContext
+
+
+_RECORDER = None
+
+
+def _prometheus_client():
+    try:
+        from prometheus_client import Counter, Gauge, Histogram, CollectorRegistry, generate_latest
+    except ImportError as exc:
+        raise ImportError("Install drf-api-logger[prometheus] to enable Prometheus metrics.") from exc
+    return Counter, Gauge, Histogram, CollectorRegistry, generate_latest
+
+
+def get_prometheus_recorder():
+    global _RECORDER
+    if _RECORDER is None:
+        _RECORDER = PrometheusMetricsRecorder()
+    return _RECORDER
+
+
+def reset_prometheus_recorder_for_tests():
+    global _RECORDER
+    _RECORDER = None
+
+
+def generate_prometheus_latest():
+    recorder = get_prometheus_recorder()
+    _, _, _, _, generate_latest = _prometheus_client()
+    return generate_latest(recorder.registry)
+
+
+class PrometheusMetricsRecorder:
+    def __init__(self):
+        Counter, Gauge, Histogram, CollectorRegistry, _ = _prometheus_client()
+        self.registry = CollectorRegistry()
+        namespace = metrics_settings.prometheus_namespace()
+        duration_buckets = metrics_settings.histogram_buckets_seconds()
+        size_buckets = metrics_settings.histogram_buckets_bytes()
+
+        http_labels = ("method", "route", "view_name", "status_class")
+        active_http_labels = ("method", "route")
+        self.http_requests = Counter(
+            "http_requests",
+            "DRF API Logger observed HTTP requests.",
+            http_labels,
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.http_active_requests = Gauge(
+            "http_active_requests",
+            "In-flight HTTP requests observed by DRF API Logger.",
+            active_http_labels,
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.http_duration = Histogram(
+            "http_request_duration_seconds",
+            "DRF API Logger observed HTTP request duration.",
+            http_labels,
+            namespace=namespace,
+            registry=self.registry,
+            buckets=duration_buckets,
+        )
+        self.http_request_body_size = Histogram(
+            "http_request_body_size_bytes",
+            "Observed request body size from Content-Length or bounded request metadata.",
+            ("method", "route"),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=size_buckets,
+        )
+        self.http_response_body_size = Histogram(
+            "http_response_body_size_bytes",
+            "Observed non-streaming response body size.",
+            ("method", "route", "status_class"),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=size_buckets,
+        )
+        self.http_slow_requests = Counter(
+            "http_slow_requests",
+            "Requests at or above DRF_API_LOGGER_SLOW_API_ABOVE.",
+            ("method", "route", "view_name"),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.http_exceptions = Counter(
+            "http_exceptions",
+            "Exceptions raised during observed request processing.",
+            ("route", "exception_class", "status_code"),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.http_throttled_requests = Counter(
+            "http_throttled_requests",
+            "HTTP 429 responses observed by DRF API Logger.",
+            ("route", "throttle_scope"),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.logger_overhead = Histogram(
+            "request_overhead_seconds",
+            "Estimated DRF API Logger request-path overhead.",
+            ("route", "logging_enabled"),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=duration_buckets,
+        )
+        self.payload_capture_duration = Histogram(
+            "payload_capture_duration_seconds",
+            "Time spent capturing request or response payloads.",
+            ("location",),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=duration_buckets,
+        )
+        self.masking_duration = Histogram(
+            "masking_duration_seconds",
+            "Time spent masking sensitive data.",
+            ("location",),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=duration_buckets,
+        )
+        self.serialization_duration = Histogram(
+            "serialization_duration_seconds",
+            "Time spent serializing log payloads.",
+            ("payload",),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=duration_buckets,
+        )
+        self.enqueue_duration = Histogram(
+            "enqueue_duration_seconds",
+            "Time spent enqueueing API log records.",
+            ("queue_name",),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=duration_buckets,
+        )
+        self.enqueued_logs = Counter(
+            "log_events_enqueued",
+            "API log records accepted into the background queue.",
+            ("queue_name",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.processed_logs = Counter(
+            "log_events_processed",
+            "API log records persisted by the background worker.",
+            ("storage_backend",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.dropped_logs = Counter(
+            "log_events_dropped",
+            "API log records dropped before persistence.",
+            ("reason",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.skipped_logs = Counter(
+            "log_events_skipped",
+            "API log records skipped by policy.",
+            ("reason",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.queue_depth = Gauge(
+            "queue_depth",
+            "Current API logger queue backlog.",
+            ("queue_name",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.queue_capacity = Gauge(
+            "queue_capacity",
+            "Configured API logger queue batch threshold.",
+            ("queue_name",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.queue_utilization = Gauge(
+            "queue_utilization_ratio",
+            "Current API logger queue depth divided by configured capacity.",
+            ("queue_name",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.worker_up = Gauge(
+            "worker_up",
+            "Whether the background API logger worker is alive.",
+            ("worker_name",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.worker_restarts = Counter(
+            "worker_restarts",
+            "Background API logger worker starts observed in this process.",
+            ("worker_name",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.flush_duration = Histogram(
+            "flush_duration_seconds",
+            "Background worker batch flush duration.",
+            ("storage_backend",),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=duration_buckets,
+        )
+        self.flush_batch_size = Histogram(
+            "flush_batch_size",
+            "Background worker batch size.",
+            ("storage_backend",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.storage_write_failures = Counter(
+            "storage_write_failures",
+            "Failed storage writes by backend and exception class.",
+            ("storage_backend", "exception_class"),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.storage_write_duration = Histogram(
+            "storage_write_duration_seconds",
+            "Storage sink write duration.",
+            ("storage_backend",),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=duration_buckets,
+        )
+        self.sql_duration = Histogram(
+            "request_sql_duration_seconds",
+            "SQL duration observed from DRF API Logger profiling data.",
+            ("route", "view_name"),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=duration_buckets,
+        )
+        self.sql_queries = Histogram(
+            "request_sql_queries",
+            "SQL query count observed from DRF API Logger profiling data.",
+            ("route", "view_name"),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.duplicate_sql_queries = Histogram(
+            "request_duplicate_sql_queries",
+            "Duplicate SQL query count observed from profiling data.",
+            ("route", "view_name"),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.n_plus_one_suspected = Counter(
+            "n_plus_one_suspected",
+            "Requests whose profiling data indicates a likely N+1 query pattern.",
+            ("route", "view_name"),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.view_duration = Histogram(
+            "view_duration_seconds",
+            "View and serialization duration from profiling data.",
+            ("route", "view_name"),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=duration_buckets,
+        )
+        self.middleware_duration = Histogram(
+            "middleware_duration_seconds",
+            "Middleware duration from profiling data.",
+            ("middleware_name",),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=duration_buckets,
+        )
+        security_labels = (
+            "event_type",
+            "category",
+            "severity",
+            "route",
+            "method",
+            "status_class",
+            "outcome",
+        )
+        self.security_events = Counter(
+            "security_events",
+            "Security or suspicious activity events observed.",
+            security_labels,
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.security_rule_matches = Counter(
+            "security_rule_matches",
+            "Security rule matches observed.",
+            ("rule_id", "category", "severity", "route", "method"),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.security_risk_score = Histogram(
+            "security_request_risk_score",
+            "Request-level security risk score distribution.",
+            ("route", "method", "status_class"),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.security_detection_duration = Histogram(
+            "security_detection_duration_seconds",
+            "Security detection engine duration.",
+            ("route",),
+            namespace=namespace,
+            registry=self.registry,
+            buckets=duration_buckets,
+        )
+        self.security_detection_errors = Counter(
+            "security_detection_errors",
+            "Security detection errors isolated from the request path.",
+            ("rule_id", "exception_class"),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.security_alerts = Counter(
+            "security_alerts",
+            "Security events at warning severity or above.",
+            ("category", "severity", "route"),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.auth_failure_bursts = Counter(
+            "auth_failure_bursts",
+            "Authentication abuse or success-after-failure signals.",
+            ("route",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.route_scan_suspected = Counter(
+            "route_scan_suspected",
+            "Route scanning signals observed.",
+            ("route",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.object_id_enumeration_suspected = Counter(
+            "object_id_enumeration_suspected",
+            "Object ID enumeration signals observed.",
+            ("route",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.payload_attack_pattern_matches = Counter(
+            "payload_attack_pattern_matches",
+            "Payload attack pattern signals observed.",
+            ("attack_type", "route"),
+            namespace=namespace,
+            registry=self.registry,
+        )
+        self.high_response_volume_suspected = Counter(
+            "high_response_volume_suspected",
+            "High response volume or export-like signals observed.",
+            ("route",),
+            namespace=namespace,
+            registry=self.registry,
+        )
+
+    def timer(self, name, labels=None):
+        labels = labels or {}
+        if name == "payload_capture":
+            return TimerContext(
+                lambda duration: self.observe_payload_capture(
+                    labels,
+                    labels.get("location", "unknown"),
+                    duration,
+                )
+            )
+        if name == "masking":
+            return TimerContext(
+                lambda duration: self.observe_masking(
+                    labels,
+                    labels.get("location", "unknown"),
+                    duration,
+                )
+            )
+        if name == "serialization":
+            return TimerContext(lambda duration: self.observe_serialization(labels, duration))
+        if name == "enqueue":
+            return TimerContext(lambda duration: self.observe_enqueue(labels, duration))
+        return TimerContext(lambda duration: None)
+
+    def increment_active_requests(self, labels):
+        if not metrics_settings.api_metrics_enabled():
+            return
+        safe = build_http_core_labels({"method": labels.get("method"), "low_cardinality": labels})
+        self.http_active_requests.labels(
+            method=safe.get("method", "unknown"),
+            route=safe.get("route", "unknown"),
+        ).inc()
+
+    def decrement_active_requests(self, labels):
+        if not metrics_settings.api_metrics_enabled():
+            return
+        safe = build_http_core_labels({"method": labels.get("method"), "low_cardinality": labels})
+        self.http_active_requests.labels(
+            method=safe.get("method", "unknown"),
+            route=safe.get("route", "unknown"),
+        ).dec()
+
+    def observe_http_request(self, event):
+        if not metrics_settings.api_metrics_enabled():
+            return
+        labels = build_http_labels(event)
+        core = build_http_core_labels(event)
+        projected = {
+            "method": core.get("method", labels.get("method", "unknown")),
+            "route": core.get("route", labels.get("route", "unknown")),
+            "view_name": core.get("view_name", labels.get("view_name", "unknown")),
+            "status_class": core.get("status_class", labels.get("status_class", "unknown")),
+        }
+        self.http_requests.labels(**projected).inc()
+        duration = event.get("execution_time")
+        if isinstance(duration, (int, float)) and duration >= 0:
+            self.http_duration.labels(**projected).observe(duration)
+        request_body_size = event.get("request_body_size_bytes")
+        if isinstance(request_body_size, int) and request_body_size >= 0:
+            self.http_request_body_size.labels(
+                method=projected["method"],
+                route=projected["route"],
+            ).observe(request_body_size)
+        response_body_size = event.get("response_body_size_bytes")
+        if isinstance(response_body_size, int) and response_body_size >= 0:
+            self.http_response_body_size.labels(
+                method=projected["method"],
+                route=projected["route"],
+                status_class=projected["status_class"],
+            ).observe(response_body_size)
+        if event.get("is_slow") is True:
+            self.http_slow_requests.labels(
+                method=projected["method"],
+                route=projected["route"],
+                view_name=projected["view_name"],
+            ).inc()
+        if str(event.get("status_code")) == "429":
+            self.http_throttled_requests.labels(
+                route=projected["route"],
+                throttle_scope=core.get("throttle_scope", "unknown"),
+            ).inc()
+
+    def increment_http_exception(self, event):
+        if not metrics_settings.api_metrics_enabled():
+            return
+        core = build_http_core_labels(event)
+        self.http_exceptions.labels(
+            route=core.get("route", "unknown"),
+            exception_class=core.get("exception_class", "Exception"),
+            status_code=core.get("status_code", "500"),
+        ).inc()
+
+    def observe_logger_overhead(self, labels, duration_seconds):
+        if not metrics_settings.logger_metrics_enabled():
+            return
+        safe = build_logger_labels(labels)
+        self.logger_overhead.labels(
+            route=safe.get("route", "unknown"),
+            logging_enabled=safe.get("logging_enabled", "unknown"),
+        ).observe(max(float(duration_seconds), 0.0))
+
+    def observe_payload_capture(self, labels, location, duration_seconds):
+        if metrics_settings.logger_metrics_enabled():
+            self.payload_capture_duration.labels(location=str(location or "unknown")).observe(
+                max(float(duration_seconds), 0.0)
+            )
+
+    def observe_masking(self, labels, location, duration_seconds):
+        if metrics_settings.logger_metrics_enabled():
+            self.masking_duration.labels(location=str(location or "unknown")).observe(
+                max(float(duration_seconds), 0.0)
+            )
+
+    def observe_serialization(self, labels, duration_seconds):
+        if metrics_settings.logger_metrics_enabled():
+            safe = build_logger_labels(labels)
+            self.serialization_duration.labels(payload=safe.get("payload", "unknown")).observe(
+                max(float(duration_seconds), 0.0)
+            )
+
+    def observe_enqueue(self, labels, duration_seconds):
+        if metrics_settings.pipeline_metrics_enabled():
+            safe = build_logger_labels(labels)
+            self.enqueue_duration.labels(queue_name=safe.get("queue_name", "default")).observe(
+                max(float(duration_seconds), 0.0)
+            )
+
+    def increment_enqueued_logs(self, queue_name="default"):
+        if metrics_settings.pipeline_metrics_enabled():
+            self.enqueued_logs.labels(queue_name=str(queue_name or "default")).inc()
+
+    def increment_processed_logs(self, storage_backend, count):
+        if metrics_settings.pipeline_metrics_enabled():
+            self.processed_logs.labels(storage_backend=str(storage_backend or "database")).inc(count)
+
+    def increment_dropped_logs(self, reason):
+        if metrics_settings.pipeline_metrics_enabled():
+            self.dropped_logs.labels(reason=str(reason or "unknown")).inc()
+
+    def increment_skipped_logs(self, reason):
+        if metrics_settings.pipeline_metrics_enabled():
+            self.skipped_logs.labels(reason=str(reason or "unknown")).inc()
+
+    def increment_storage_write_failure(self, storage_backend, exception_class):
+        if metrics_settings.pipeline_metrics_enabled():
+            self.storage_write_failures.labels(
+                storage_backend=str(storage_backend or "database"),
+                exception_class=str(exception_class or "Exception"),
+            ).inc()
+
+    def set_queue_depth(self, queue_name, depth):
+        if metrics_settings.pipeline_metrics_enabled():
+            self.queue_depth.labels(queue_name=str(queue_name or "default")).set(max(int(depth), 0))
+
+    def set_queue_capacity(self, queue_name, capacity):
+        if metrics_settings.pipeline_metrics_enabled():
+            self.queue_capacity.labels(queue_name=str(queue_name or "default")).set(max(int(capacity), 0))
+
+    def set_queue_utilization(self, queue_name, ratio):
+        if metrics_settings.pipeline_metrics_enabled():
+            try:
+                ratio = float(ratio)
+            except (TypeError, ValueError):
+                ratio = 0.0
+            self.queue_utilization.labels(queue_name=str(queue_name or "default")).set(max(ratio, 0.0))
+
+    def set_worker_up(self, worker_name, up):
+        if metrics_settings.pipeline_metrics_enabled():
+            self.worker_up.labels(worker_name=str(worker_name or "worker")).set(1 if up else 0)
+
+    def increment_worker_restart(self, worker_name):
+        if metrics_settings.pipeline_metrics_enabled():
+            self.worker_restarts.labels(worker_name=str(worker_name or "worker")).inc()
+
+    def observe_flush(self, storage_backend, duration_seconds, batch_size):
+        if metrics_settings.pipeline_metrics_enabled():
+            backend = str(storage_backend or "database")
+            self.flush_duration.labels(storage_backend=backend).observe(max(float(duration_seconds), 0.0))
+            self.flush_batch_size.labels(storage_backend=backend).observe(max(int(batch_size), 0))
+
+    def observe_storage_write(self, storage_backend, duration_seconds):
+        if metrics_settings.pipeline_metrics_enabled():
+            backend = str(storage_backend or "database")
+            self.storage_write_duration.labels(storage_backend=backend).observe(max(float(duration_seconds), 0.0))
+
+    def observe_profiling(self, labels, profiling):
+        if not metrics_settings.profiling_metrics_enabled():
+            return
+        safe = build_logger_labels(labels)
+        route = safe.get("route", "unknown")
+        view_name = safe.get("view_name", "unknown")
+        sql = profiling.get("sql") or {}
+        sql_time = sql.get("total_time")
+        query_count = sql.get("query_count")
+        duplicate_queries = sql.get("duplicate_query_count")
+        if isinstance(sql_time, (int, float)) and sql_time >= 0:
+            self.sql_duration.labels(route=route, view_name=view_name).observe(sql_time)
+        if isinstance(query_count, int) and query_count >= 0:
+            self.sql_queries.labels(route=route, view_name=view_name).observe(query_count)
+        if isinstance(duplicate_queries, int) and duplicate_queries >= 0:
+            self.duplicate_sql_queries.labels(route=route, view_name=view_name).observe(duplicate_queries)
+        view_duration = profiling.get("view_and_serialization")
+        if isinstance(view_duration, (int, float)) and view_duration >= 0:
+            self.view_duration.labels(route=route, view_name=view_name).observe(view_duration)
+        middleware_before = profiling.get("middleware_before_view")
+        if isinstance(middleware_before, (int, float)) and middleware_before >= 0:
+            self.middleware_duration.labels(middleware_name="before_view").observe(middleware_before)
+        middleware_after = profiling.get("middleware_after_view")
+        if isinstance(middleware_after, (int, float)) and middleware_after >= 0:
+            self.middleware_duration.labels(middleware_name="after_view").observe(middleware_after)
+        if isinstance(query_count, int) and isinstance(sql_time, (int, float)):
+            total = profiling.get("view_and_serialization") or 0
+            sql_pct = (sql_time / total) * 100 if total > 0 else 0
+            if sql_pct > 70 and query_count >= 10:
+                self.n_plus_one_suspected.labels(route=route, view_name=view_name).inc()
+
+    def observe_security_event(self, signal):
+        if not metrics_settings.security_metrics_enabled():
+            return
+        labels = build_security_labels(signal)
+        self.security_events.labels(
+            event_type=labels["event_type"],
+            category=labels["category"],
+            severity=labels["severity"],
+            route=labels["route"],
+            method=labels["method"],
+            status_class=labels["status_class"],
+            outcome=labels["outcome"],
+        ).inc()
+        self.security_rule_matches.labels(
+            rule_id=labels["rule_id"],
+            category=labels["category"],
+            severity=labels["severity"],
+            route=labels["route"],
+            method=labels["method"],
+        ).inc()
+        self.security_risk_score.labels(
+            route=labels["route"],
+            method=labels["method"],
+            status_class=labels["status_class"],
+        ).observe(max(int(signal.score), 0))
+        if labels["severity"] in {"warning", "error", "critical"}:
+            self.security_alerts.labels(
+                category=labels["category"],
+                severity=labels["severity"],
+                route=labels["route"],
+            ).inc()
+        if signal.event_type in {"auth_failure", "success_after_auth_failures", "token_failure_burst"}:
+            self.auth_failure_bursts.labels(route=labels["route"]).inc()
+        if signal.event_type == "route_scan_suspected":
+            self.route_scan_suspected.labels(route=labels["route"]).inc()
+        if signal.event_type == "object_id_enumeration_suspected":
+            self.object_id_enumeration_suspected.labels(route=labels["route"]).inc()
+        if signal.event_type in {"payload_attack_pattern", "log_injection_attempt"}:
+            self.payload_attack_pattern_matches.labels(
+                attack_type=labels["reason"],
+                route=labels["route"],
+            ).inc()
+        if signal.event_type in {"high_response_volume_suspected", "bulk_export_suspected"}:
+            self.high_response_volume_suspected.labels(route=labels["route"]).inc()
+
+    def observe_security_detection(self, labels, duration_seconds):
+        if metrics_settings.security_metrics_enabled():
+            safe = build_logger_labels(labels)
+            self.security_detection_duration.labels(route=safe.get("route", "unknown")).observe(
+                max(float(duration_seconds), 0.0)
+            )
+
+    def increment_security_detection_error(self, rule_id, exception_class):
+        if metrics_settings.security_metrics_enabled():
+            self.security_detection_errors.labels(
+                rule_id=str(rule_id or "unknown"),
+                exception_class=str(exception_class or "Exception"),
+            ).inc()

--- a/drf_api_logger/metrics/recorder.py
+++ b/drf_api_logger/metrics/recorder.py
@@ -1,0 +1,37 @@
+import time
+
+from drf_api_logger.metrics import settings as metrics_settings
+from drf_api_logger.metrics.noop import NoOpMetricsRecorder
+
+
+NOOP_RECORDER = NoOpMetricsRecorder()
+
+
+class TimerContext:
+    def __init__(self, observer):
+        self.observer = observer
+        self.start = None
+
+    def __enter__(self):
+        self.start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self.start is not None:
+            self.observer(time.perf_counter() - self.start)
+        return False
+
+
+def get_recorder():
+    if not metrics_settings.metrics_enabled():
+        return NOOP_RECORDER
+    if metrics_settings.metrics_exporter() == "none":
+        return NOOP_RECORDER
+    try:
+        from drf_api_logger.metrics.prometheus import get_prometheus_recorder
+    except ImportError:
+        return NOOP_RECORDER
+    try:
+        return get_prometheus_recorder()
+    except ImportError:
+        return NOOP_RECORDER

--- a/drf_api_logger/metrics/rules.py
+++ b/drf_api_logger/metrics/rules.py
@@ -1,0 +1,374 @@
+import re
+
+from drf_api_logger.metrics import settings as metrics_settings
+from drf_api_logger.metrics.security import SecuritySignal
+from drf_api_logger.metrics.state import BoundedRollingState
+
+
+PAYLOAD_ATTACK_RE = re.compile(
+    rb"(<script\b|javascript:|union\s+select|\bor\b\s+1\s*=\s*1|--|/\*|\.\./|%2e%2e)",
+    re.IGNORECASE,
+)
+LOG_INJECTION_RE = re.compile(rb"(\r\n|\n|\r)")
+OBJECT_ID_PATH_RE = re.compile(r"/\d+(?:/|$)")
+
+
+def _new_state():
+    return BoundedRollingState(max_keys=1000, ttl_seconds=metrics_settings.security_window_seconds())
+
+
+AUTH_FAILURE_STATE = _new_state()
+OBJECT_ENUMERATION_STATE = _new_state()
+PAGINATION_SWEEP_STATE = _new_state()
+BUSINESS_FLOW_STATE = _new_state()
+
+
+def reset_security_rule_state_for_tests():
+    global AUTH_FAILURE_STATE, OBJECT_ENUMERATION_STATE, PAGINATION_SWEEP_STATE, BUSINESS_FLOW_STATE
+    AUTH_FAILURE_STATE = _new_state()
+    OBJECT_ENUMERATION_STATE = _new_state()
+    PAGINATION_SWEEP_STATE = _new_state()
+    BUSINESS_FLOW_STATE = _new_state()
+
+
+def _body_sample(context):
+    sample = context.request_body_sample
+    if sample is None:
+        return b""
+    if isinstance(sample, bytes):
+        return sample
+    try:
+        return str(sample).encode("utf-8", errors="ignore")
+    except Exception:
+        return b""
+
+
+def _response_sample(context):
+    sample = context.response_body_sample
+    if sample is None:
+        return b""
+    if isinstance(sample, bytes):
+        return sample
+    try:
+        return str(sample).encode("utf-8", errors="ignore")
+    except Exception:
+        return b""
+
+
+def _signal(context, rule_id, event_type, category, severity, score, reason="unknown"):
+    return SecuritySignal(
+        rule_id=rule_id,
+        event_type=event_type,
+        category=category,
+        severity=severity,
+        score=score,
+        route=context.route or "unknown",
+        method=context.method or "unknown",
+        status_class=context.status_class or "unknown",
+        outcome="observed",
+        reason=reason,
+    )
+
+
+def _actor_key(context, suffix):
+    actor = context.actor_fingerprint or "anonymous"
+    route = context.route or "unknown"
+    return "{}:{}:{}".format(suffix, actor, route)
+
+
+def _request_path(context):
+    request = getattr(context, "request", None)
+    path = getattr(request, "path", "")
+    return str(path or "")
+
+
+def _query_value(context, key):
+    request = getattr(context, "request", None)
+    query = getattr(request, "GET", None)
+    if not query:
+        return None
+    try:
+        if hasattr(query, "get"):
+            return query.get(key)
+        return query[key]
+    except Exception:
+        return None
+
+
+class SecurityRule:
+    rule_id = "DRFSEC-000"
+    category = "unknown"
+
+    def evaluate(self, context):
+        return []
+
+
+class AuthFailureRule(SecurityRule):
+    rule_id = "DRFSEC-001"
+    category = "authentication"
+
+    def evaluate(self, context):
+        if context.status_code == 401:
+            AUTH_FAILURE_STATE.increment(_actor_key(context, "auth_failure"))
+            return [_signal(context, self.rule_id, "auth_failure", self.category, "warning", 3, "auth_failure")]
+        return []
+
+
+class SuccessAfterFailuresRule(SecurityRule):
+    rule_id = "DRFSEC-002"
+    category = "authentication"
+
+    def evaluate(self, context):
+        if context.status_code is None or context.status_code < 200 or context.status_code > 299:
+            return []
+        count = AUTH_FAILURE_STATE.get(_actor_key(context, "auth_failure"))
+        if count >= 3:
+            return [
+                _signal(
+                    context,
+                    self.rule_id,
+                    "success_after_auth_failures",
+                    self.category,
+                    "warning",
+                    4,
+                    "success_after_failures",
+                )
+            ]
+        return []
+
+
+class TokenFailureRule(SecurityRule):
+    rule_id = "DRFSEC-003"
+    category = "token"
+
+    def evaluate(self, context):
+        route = str(context.route or "").lower()
+        if context.status_code == 401 and ("token" in route or "auth" in route):
+            return [_signal(context, self.rule_id, "token_failure_burst", self.category, "warning", 3, "token_failure")]
+        return []
+
+
+class AuthorizationFailureRule(SecurityRule):
+    rule_id = "DRFSEC-004"
+    category = "authorization"
+
+    def evaluate(self, context):
+        if context.status_code == 403:
+            return [
+                _signal(
+                    context,
+                    self.rule_id,
+                    "authorization_failure",
+                    self.category,
+                    "warning",
+                    3,
+                    "authorization_failure",
+                )
+            ]
+        return []
+
+
+class AdminProbeRule(SecurityRule):
+    rule_id = "DRFSEC-005"
+    category = "reconnaissance"
+
+    def evaluate(self, context):
+        route = str(context.route or "").lower()
+        if "admin" in route or "debug" in route:
+            return [_signal(context, self.rule_id, "admin_probe", self.category, "warning", 3, "admin_probe")]
+        return []
+
+
+class PayloadAttackPatternRule(SecurityRule):
+    rule_id = "DRFSEC-006"
+    category = "payload"
+
+    def evaluate(self, context):
+        sample = _body_sample(context)
+        if sample and PAYLOAD_ATTACK_RE.search(sample):
+            return [
+                _signal(
+                    context,
+                    self.rule_id,
+                    "payload_attack_pattern",
+                    self.category,
+                    "warning",
+                    4,
+                    "payload_pattern",
+                )
+            ]
+        return []
+
+
+class RateLimitPressureRule(SecurityRule):
+    rule_id = "DRFSEC-007"
+    category = "resource_abuse"
+
+    def evaluate(self, context):
+        if context.status_code == 429:
+            return [_signal(context, self.rule_id, "rate_limit_pressure", self.category, "warning", 3, "rate_limited")]
+        return []
+
+
+class RouteScanRule(SecurityRule):
+    rule_id = "DRFSEC-008"
+    category = "reconnaissance"
+
+    def evaluate(self, context):
+        if context.status_code == 404:
+            return [_signal(context, self.rule_id, "route_scan_suspected", self.category, "notice", 2, "not_found")]
+        return []
+
+
+class ObjectIdEnumerationRule(SecurityRule):
+    rule_id = "DRFSEC-009"
+    category = "authorization"
+
+    def evaluate(self, context):
+        if context.status_code not in (403, 404):
+            return []
+        path = _request_path(context)
+        route = str(context.route or "")
+        if not (OBJECT_ID_PATH_RE.search(path) or "<int:" in route or "<uuid:" in route):
+            return []
+        count = OBJECT_ENUMERATION_STATE.increment(_actor_key(context, "object_id"))
+        if count >= 3:
+            return [
+                _signal(
+                    context,
+                    self.rule_id,
+                    "object_id_enumeration_suspected",
+                    self.category,
+                    "warning",
+                    4,
+                    "object_probe",
+                )
+            ]
+        return []
+
+
+class LogInjectionRule(SecurityRule):
+    rule_id = "DRFSEC-010"
+    category = "payload"
+
+    def evaluate(self, context):
+        sample = _body_sample(context)
+        if sample and LOG_INJECTION_RE.search(sample):
+            return [_signal(context, self.rule_id, "log_injection_attempt", self.category, "notice", 2, "control_chars")]
+        return []
+
+
+class SensitiveFieldExposureRule(SecurityRule):
+    rule_id = "DRFSEC-011"
+    category = "data_exposure"
+
+    def evaluate(self, context):
+        sample = _response_sample(context).lower()
+        if b"password" in sample or b"api_key" in sample or b"authorization" in sample:
+            return [
+                _signal(
+                    context,
+                    self.rule_id,
+                    "sensitive_field_exposure_suspected",
+                    self.category,
+                    "warning",
+                    4,
+                    "sensitive_field",
+                )
+            ]
+        return []
+
+
+class PaginationSweepRule(SecurityRule):
+    rule_id = "DRFSEC-012"
+    category = "scraping"
+
+    def evaluate(self, context):
+        page = _query_value(context, "page")
+        cursor = _query_value(context, "cursor")
+        if page is None and cursor is None:
+            return []
+        count = PAGINATION_SWEEP_STATE.increment(_actor_key(context, "pagination"))
+        if count >= 3:
+            return [_signal(context, self.rule_id, "pagination_sweep_suspected", self.category, "notice", 2)]
+        return []
+
+
+class BulkExportSpikeRule(SecurityRule):
+    rule_id = "DRFSEC-013"
+    category = "data_exfiltration"
+
+    def evaluate(self, context):
+        route = str(context.route or "").lower()
+        action = str(context.business_context.get("business_action", "")).lower()
+        if any(marker in route for marker in ("export", "download", "report")) or "export" in action:
+            return [_signal(context, self.rule_id, "bulk_export_suspected", self.category, "warning", 4)]
+        return []
+
+
+class HighResponseVolumeRule(SecurityRule):
+    rule_id = "DRFSEC-014"
+    category = "data_exfiltration"
+
+    def evaluate(self, context):
+        sample = _response_sample(context)
+        if len(sample) >= 8192:
+            return [_signal(context, self.rule_id, "high_response_volume_suspected", self.category, "notice", 2)]
+        return []
+
+
+class SensitiveBusinessRouteRule(SecurityRule):
+    rule_id = "DRFSEC-015"
+    category = "business_logic"
+
+    def evaluate(self, context):
+        if context.business_context.get("is_sensitive_route") is True:
+            return [_signal(context, self.rule_id, "sensitive_route_access", self.category, "notice", 2)]
+        return []
+
+
+class BusinessFlowAbuseRule(SecurityRule):
+    rule_id = "DRFSEC-016"
+    category = "business_logic"
+
+    def evaluate(self, context):
+        flow = context.business_context.get("flow_name")
+        action = context.business_context.get("business_action")
+        if not flow or not action:
+            return []
+        key = "{}:{}:{}:{}".format(
+            "business_flow",
+            context.actor_fingerprint or "anonymous",
+            flow,
+            action,
+        )
+        count = BUSINESS_FLOW_STATE.increment(key)
+        if count >= 3:
+            return [_signal(context, self.rule_id, "business_flow_abuse_suspected", self.category, "warning", 4)]
+        return []
+
+
+RULES = (
+    ("auth_abuse", AuthFailureRule()),
+    ("auth_abuse", SuccessAfterFailuresRule()),
+    ("token_abuse", TokenFailureRule()),
+    ("auth_abuse", AuthorizationFailureRule()),
+    ("admin_probe", AdminProbeRule()),
+    ("payload_attack_patterns", PayloadAttackPatternRule()),
+    ("resource_abuse", RateLimitPressureRule()),
+    ("route_scan", RouteScanRule()),
+    ("object_id_enumeration", ObjectIdEnumerationRule()),
+    ("payload_attack_patterns", LogInjectionRule()),
+    ("payload_attack_patterns", SensitiveFieldExposureRule()),
+    ("data_exfiltration", PaginationSweepRule()),
+    ("data_exfiltration", BulkExportSpikeRule()),
+    ("data_exfiltration", HighResponseVolumeRule()),
+    ("business_logic_hooks", SensitiveBusinessRouteRule()),
+    ("business_logic_hooks", BusinessFlowAbuseRule()),
+)
+
+
+def iter_security_rules(enabled_rules):
+    for setting_key, rule in RULES:
+        if enabled_rules.get(setting_key, False):
+            yield rule

--- a/drf_api_logger/metrics/security.py
+++ b/drf_api_logger/metrics/security.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+
+from drf_api_logger.metrics import settings as metrics_settings
+from drf_api_logger.metrics.labels import _safe_enum_value
+
+
+@dataclass(frozen=True)
+class SecuritySignal:
+    rule_id: str
+    event_type: str
+    category: str
+    severity: str
+    score: int
+    route: str
+    method: str
+    status_class: str
+    outcome: str = "observed"
+    reason: str = "unknown"
+
+
+@dataclass
+class SecurityContext:
+    request: object
+    response: object | None
+    exception: Exception | None
+    route: str
+    method: str
+    status_code: int | None
+    status_class: str
+    request_body_sample: str | bytes | None
+    response_body_sample: str | bytes | None
+    actor_fingerprint: str | None
+    low_cardinality: dict
+    business_context: dict
+
+
+def enabled_rules():
+    configured = metrics_settings.security_rules_config()
+    return {
+        "auth_abuse": configured.get("auth_abuse", True),
+        "token_abuse": configured.get("token_abuse", True),
+        "route_scan": configured.get("route_scan", True),
+        "admin_probe": configured.get("admin_probe", True),
+        "object_id_enumeration": configured.get("object_id_enumeration", True),
+        "payload_attack_patterns": configured.get("payload_attack_patterns", True),
+        "resource_abuse": configured.get("resource_abuse", True),
+        "data_exfiltration": configured.get("data_exfiltration", True),
+        "business_logic_hooks": configured.get("business_logic_hooks", False),
+    }
+
+
+def sanitize_business_context(value):
+    if not isinstance(value, dict):
+        return {}
+    safe = {}
+    for key in ("actor_type", "business_action", "resource_type", "flow_name"):
+        if key in value:
+            safe[key] = _safe_enum_value(value.get(key))
+    if "is_sensitive_route" in value:
+        safe["is_sensitive_route"] = value.get("is_sensitive_route") is True
+    return safe
+
+
+def evaluate_security_signals(context, error_callback=None):
+    from drf_api_logger.metrics.rules import iter_security_rules
+
+    signals = []
+    rules = enabled_rules()
+    for rule in iter_security_rules(rules):
+        try:
+            signals.extend(rule.evaluate(context))
+        except Exception as exc:
+            if error_callback is not None:
+                error_callback(getattr(rule, "rule_id", "unknown"), exc)
+    return signals

--- a/drf_api_logger/metrics/settings.py
+++ b/drf_api_logger/metrics/settings.py
@@ -1,0 +1,298 @@
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+
+UNKNOWN_LABEL_VALUE = "unknown"
+
+DEFAULT_METRICS_GROUPS = ("logger", "pipeline")
+DEFAULT_METRIC_LABELS = ("method", "route", "view_name", "status_class")
+
+ALLOWED_LABELS = frozenset(
+    {
+        "method",
+        "route",
+        "view_name",
+        "url_name",
+        "app_name",
+        "namespace",
+        "status_code",
+        "status_class",
+        "exception_class",
+        "auth_scheme",
+        "reason",
+        "severity",
+        "category",
+        "rule_id",
+        "event_type",
+        "attack_type",
+        "location",
+        "payload",
+        "queue_name",
+        "worker_name",
+        "storage_backend",
+        "logging_enabled",
+        "outcome",
+        "throttle_scope",
+        "feature",
+        "middleware_name",
+        "renderer",
+    }
+)
+
+FORBIDDEN_LABELS = frozenset(
+    {
+        "raw_path",
+        "full_url",
+        "query_string",
+        "request_id",
+        "trace_id",
+        "user_id",
+        "email",
+        "username",
+        "client_ip",
+        "authorization_header",
+        "token",
+        "api_key",
+        "session_id",
+        "object_id",
+        "tenant_id",
+        "actor_id",
+        "sql_query",
+        "exception_message",
+        "request_body",
+        "response_body",
+        "full_user_agent",
+    }
+)
+
+
+def _setting(name, default):
+    return getattr(settings, name, default)
+
+
+def _as_bool(name, default=False):
+    return bool(_setting(name, default))
+
+
+def metrics_enabled():
+    return _as_bool("DRF_API_LOGGER_METRICS_ENABLED", False)
+
+
+def metrics_exporter():
+    value = _setting("DRF_API_LOGGER_METRICS_EXPORTER", "prometheus")
+    if value not in ("none", "prometheus"):
+        return "prometheus"
+    return value
+
+
+def metrics_groups():
+    value = _setting("DRF_API_LOGGER_METRICS_GROUPS", DEFAULT_METRICS_GROUPS)
+    if not isinstance(value, (list, tuple, set)):
+        return DEFAULT_METRICS_GROUPS
+    normalized = []
+    for group in value:
+        text = str(group).strip().lower()
+        if text in {"api", "logger", "pipeline", "profiling", "security"}:
+            normalized.append(text)
+    return tuple(normalized) or DEFAULT_METRICS_GROUPS
+
+
+def metric_label_keys():
+    value = _setting("DRF_API_LOGGER_METRICS_LABELS", DEFAULT_METRIC_LABELS)
+    if not isinstance(value, (list, tuple)):
+        value = DEFAULT_METRIC_LABELS
+    return tuple(label for label in value if label in ALLOWED_LABELS)
+
+
+def unsafe_metric_label_keys():
+    value = _setting("DRF_API_LOGGER_METRICS_LABELS", DEFAULT_METRIC_LABELS)
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(label for label in value if label not in ALLOWED_LABELS or label in FORBIDDEN_LABELS)
+
+
+def max_label_length():
+    value = _setting("DRF_API_LOGGER_METRICS_MAX_LABEL_LENGTH", 128)
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return 128
+
+
+def prometheus_namespace():
+    value = str(_setting("DRF_API_LOGGER_METRICS_PROMETHEUS_NAMESPACE", "drf_api_logger")).strip()
+    return value or "drf_api_logger"
+
+
+def prometheus_endpoint_enabled():
+    return _as_bool("DRF_API_LOGGER_METRICS_PROMETHEUS_ENDPOINT_ENABLED", False)
+
+
+def prometheus_endpoint_path():
+    value = str(_setting("DRF_API_LOGGER_METRICS_PROMETHEUS_ENDPOINT_PATH", "metrics/")).strip()
+    if not value:
+        return "metrics/"
+    return value if value.endswith("/") else value + "/"
+
+
+def histogram_buckets_seconds():
+    value = _setting(
+        "DRF_API_LOGGER_METRICS_HISTOGRAM_BUCKETS_SECONDS",
+        (
+            0.001,
+            0.0025,
+            0.005,
+            0.01,
+            0.025,
+            0.05,
+            0.1,
+            0.25,
+            0.5,
+            1,
+            2.5,
+            5,
+            10,
+        ),
+    )
+    if not isinstance(value, (list, tuple)):
+        return None
+    buckets = []
+    for item in value:
+        if isinstance(item, (int, float)) and not isinstance(item, bool) and item > 0:
+            buckets.append(float(item))
+    return tuple(buckets) or None
+
+
+def histogram_buckets_bytes():
+    value = _setting(
+        "DRF_API_LOGGER_METRICS_SIZE_BUCKETS_BYTES",
+        (
+            100,
+            500,
+            1000,
+            5000,
+            10000,
+            50000,
+            100000,
+            500000,
+            1000000,
+            5000000,
+        ),
+    )
+    if not isinstance(value, (list, tuple)):
+        return None
+    buckets = []
+    for item in value:
+        if isinstance(item, (int, float)) and not isinstance(item, bool) and item > 0:
+            buckets.append(float(item))
+    return tuple(buckets) or None
+
+
+def slow_request_threshold_seconds():
+    value = _setting("DRF_API_LOGGER_SLOW_API_ABOVE", None)
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value / 1000.0
+    return None
+
+
+def api_metrics_enabled():
+    return metrics_enabled() and _as_bool("DRF_API_LOGGER_API_METRICS_ENABLED", False)
+
+
+def logger_metrics_enabled():
+    return metrics_enabled() and "logger" in metrics_groups()
+
+
+def pipeline_metrics_enabled():
+    return metrics_enabled() and "pipeline" in metrics_groups()
+
+
+def profiling_metrics_enabled():
+    return metrics_enabled() and "profiling" in metrics_groups()
+
+
+def security_metrics_enabled():
+    return (
+        metrics_enabled()
+        and _as_bool("DRF_API_LOGGER_SECURITY_METRICS_ENABLED", False)
+        and "security" in set(metrics_groups() + ("security",))
+    )
+
+
+def request_metrics_enabled():
+    return api_metrics_enabled() or security_metrics_enabled()
+
+
+def security_mode():
+    return "detect"
+
+
+def security_body_inspection_config():
+    default = {
+        "enabled": True,
+        "max_body_bytes": 8192,
+        "inspect_request_body": True,
+        "inspect_response_body": False,
+    }
+    value = _setting("DRF_API_LOGGER_SECURITY_BODY_INSPECTION", default)
+    if not isinstance(value, dict):
+        value = {}
+    config = default.copy()
+    config.update(value)
+    return config
+
+
+def security_body_inspection_limit():
+    value = security_body_inspection_config().get("max_body_bytes", 8192)
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return 8192
+
+
+def inspect_request_body_for_security():
+    config = security_body_inspection_config()
+    return bool(config.get("enabled", True)) and bool(config.get("inspect_request_body", True))
+
+
+def inspect_response_body_for_security():
+    config = security_body_inspection_config()
+    return bool(config.get("enabled", True)) and bool(config.get("inspect_response_body", False))
+
+
+def security_rules_config():
+    value = _setting("DRF_API_LOGGER_SECURITY_RULES", {})
+    return value if isinstance(value, dict) else {}
+
+
+def security_window_seconds():
+    value = _setting("DRF_API_LOGGER_SECURITY_WINDOW_SECONDS", 300)
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return 300
+
+
+def security_actor_tracking_config():
+    default = {
+        "enabled": True,
+        "strategy": "hmac_fingerprint",
+        "include_user_id": True,
+        "include_ip": True,
+        "include_user_agent_family": True,
+    }
+    value = _setting("DRF_API_LOGGER_SECURITY_ACTOR_TRACKING", default)
+    if not isinstance(value, dict):
+        value = {}
+    config = default.copy()
+    config.update(value)
+    return config
+
+
+def security_context_getter():
+    dotted_path = _setting("DRF_API_LOGGER_SECURITY_CONTEXT_GETTER", None)
+    if not dotted_path:
+        return None
+    if callable(dotted_path):
+        return dotted_path
+    try:
+        return import_string(str(dotted_path))
+    except Exception:
+        return None

--- a/drf_api_logger/metrics/state.py
+++ b/drf_api_logger/metrics/state.py
@@ -1,0 +1,42 @@
+import time
+from collections import OrderedDict
+from threading import Lock
+
+
+class BoundedRollingState:
+    def __init__(self, max_keys=1000, ttl_seconds=300):
+        self.max_keys = max_keys
+        self.ttl_seconds = ttl_seconds
+        self._values = OrderedDict()
+        self._lock = Lock()
+
+    def increment(self, key, now=None):
+        now = now or time.time()
+        with self._lock:
+            self._evict_expired(now)
+            count, _ = self._values.get(key, (0, now))
+            count += 1
+            self._values[key] = (count, now)
+            self._values.move_to_end(key)
+            self._evict_capacity()
+            return count
+
+    def get(self, key, now=None):
+        now = now or time.time()
+        with self._lock:
+            self._evict_expired(now)
+            count, _ = self._values.get(key, (0, now))
+            return count
+
+    def _evict_expired(self, now):
+        expired = [
+            key
+            for key, (_, updated_at) in self._values.items()
+            if now - updated_at > self.ttl_seconds
+        ]
+        for key in expired:
+            self._values.pop(key, None)
+
+    def _evict_capacity(self):
+        while len(self._values) > self.max_keys:
+            self._values.popitem(last=False)

--- a/drf_api_logger/metrics/system_checks.py
+++ b/drf_api_logger/metrics/system_checks.py
@@ -1,0 +1,75 @@
+import importlib.util
+import os
+
+from django.core.checks import Error, Warning, register
+
+from drf_api_logger.metrics import settings as metrics_settings
+
+
+@register()
+def check_metrics_configuration(app_configs, **kwargs):
+    messages = []
+    if not metrics_settings.metrics_enabled():
+        return messages
+
+    if (
+        metrics_settings.metrics_exporter() == "prometheus"
+        and importlib.util.find_spec("prometheus_client") is None
+    ):
+        messages.append(
+            Error(
+                "Prometheus metrics are enabled but prometheus_client is not installed.",
+                hint="Install drf-api-logger[prometheus] or set DRF_API_LOGGER_METRICS_EXPORTER='none'.",
+                id="drf_api_logger.E701",
+            )
+        )
+
+    unsafe_labels = metrics_settings.unsafe_metric_label_keys()
+    if unsafe_labels:
+        messages.append(
+            Error(
+                "Unsafe metric labels are configured: {}.".format(", ".join(unsafe_labels)),
+                hint="Use only low-cardinality labels such as method, route, view_name, and status_class.",
+                id="drf_api_logger.E702",
+            )
+        )
+
+    if metrics_settings.prometheus_endpoint_enabled():
+        messages.append(
+            Warning(
+                "The DRF API Logger Prometheus endpoint is enabled.",
+                hint="Expose it only on an internal network, behind authentication, or through a protected scrape path.",
+                id="drf_api_logger.W703",
+            )
+        )
+
+    if (
+        metrics_settings.metrics_exporter() == "prometheus"
+        and not os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+        and (
+            os.environ.get("WEB_CONCURRENCY")
+            or os.environ.get("GUNICORN_CMD_ARGS")
+            or os.environ.get("UWSGI_ORIGINAL_PROC_NAME")
+        )
+    ):
+        messages.append(
+            Warning(
+                "Prometheus metrics appear to be enabled in a multiprocess deployment.",
+                hint="Configure prometheus_client multiprocess mode or scrape each process separately.",
+                id="drf_api_logger.W705",
+            )
+        )
+
+    if metrics_settings.security_metrics_enabled():
+        body_config = metrics_settings.security_body_inspection_config()
+        max_body_bytes = body_config.get("max_body_bytes")
+        if not isinstance(max_body_bytes, int) or isinstance(max_body_bytes, bool) or max_body_bytes < 0:
+            messages.append(
+                Error(
+                    "Security body inspection must use a finite non-negative max_body_bytes value.",
+                    hint="Set DRF_API_LOGGER_SECURITY_BODY_INSPECTION['max_body_bytes'] to 8192 or another finite byte count.",
+                    id="drf_api_logger.E704",
+                )
+            )
+
+    return messages

--- a/drf_api_logger/metrics/urls.py
+++ b/drf_api_logger/metrics/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from drf_api_logger.metrics import settings as metrics_settings
+from drf_api_logger.metrics.views import prometheus_metrics_view
+
+
+urlpatterns = [
+    path(
+        metrics_settings.prometheus_endpoint_path(),
+        prometheus_metrics_view,
+        name="drf_api_logger_prometheus_metrics",
+    ),
+]

--- a/drf_api_logger/metrics/views.py
+++ b/drf_api_logger/metrics/views.py
@@ -1,0 +1,20 @@
+from django.http import Http404, HttpResponse
+
+from drf_api_logger.metrics import settings as metrics_settings
+
+
+def generate_prometheus_latest():
+    from drf_api_logger.metrics.prometheus import generate_prometheus_latest as generate_latest
+
+    return generate_latest()
+
+
+def prometheus_metrics_view(request):
+    if not metrics_settings.prometheus_endpoint_enabled():
+        raise Http404("DRF API Logger metrics endpoint is disabled.")
+
+    payload = generate_prometheus_latest()
+    return HttpResponse(
+        payload,
+        content_type="text/plain; version=0.0.4; charset=utf-8",
+    )

--- a/drf_api_logger/middleware/api_logger_middleware.py
+++ b/drf_api_logger/middleware/api_logger_middleware.py
@@ -1,4 +1,6 @@
 import importlib
+import hashlib
+import hmac
 import json
 import random
 import time
@@ -14,6 +16,14 @@ from drf_api_logger import apps as logger_apps
 from drf_api_logger import API_LOGGER_SIGNAL
 from drf_api_logger.correlation import build_correlation_context, build_low_cardinality_metadata
 from drf_api_logger.logging_context import clear_correlation_context, set_correlation_context
+from drf_api_logger.metrics import settings as metrics_settings
+from drf_api_logger.metrics.labels import build_low_cardinality_from_resolver
+from drf_api_logger.metrics.recorder import get_recorder
+from drf_api_logger.metrics.security import (
+    SecurityContext,
+    evaluate_security_signals,
+    sanitize_business_context,
+)
 from drf_api_logger.policy import safe_evaluate_logging_policy
 from drf_api_logger.utils import get_headers, get_client_ip, mask_sensitive_data
 
@@ -286,8 +296,15 @@ class APILoggerMiddleware:
             return False
         return True
 
-    def _api_logger_enabled(self):
+    def _api_logger_storage_enabled(self):
         return self.DRF_API_LOGGER_DATABASE or self.DRF_API_LOGGER_SIGNAL
+
+    def _api_logger_enabled(self):
+        return (
+            self._api_logger_storage_enabled()
+            or metrics_settings.request_metrics_enabled()
+            or metrics_settings.profiling_metrics_enabled()
+        )
 
     def _resolve_request(self, request):
         try:
@@ -333,13 +350,237 @@ class APILoggerMiddleware:
         try:
             queries = connection.queries[:]
             sql_total_time = sum(float(query.get('time', 0)) for query in queries)
+            sql_counts = {}
+            for query in queries:
+                sql = query.get('sql')
+                if sql:
+                    sql_counts[sql] = sql_counts.get(sql, 0) + 1
+            duplicate_query_count = sum(count - 1 for count in sql_counts.values() if count > 1)
             return {
                 'total_time': round(sql_total_time, 5),
                 'query_count': len(queries),
+                'duplicate_query_count': duplicate_query_count,
             }
         finally:
             connection.force_debug_cursor = original_force_debug_cursor
             reset_queries()
+
+    def _get_request_body_sample(self, request):
+        if not metrics_settings.security_metrics_enabled():
+            return None
+        if not metrics_settings.inspect_request_body_for_security():
+            return None
+        limit = metrics_settings.security_body_inspection_limit()
+        if limit <= 0:
+            return b""
+        try:
+            return request.body[:limit]
+        except Exception:
+            return None
+
+    def _get_response_body_sample(self, response):
+        if not metrics_settings.security_metrics_enabled():
+            return None
+        if not metrics_settings.inspect_response_body_for_security():
+            return None
+        if getattr(response, 'streaming', False):
+            return None
+        limit = metrics_settings.security_body_inspection_limit()
+        if limit <= 0:
+            return b""
+        try:
+            return response.content[:limit]
+        except Exception:
+            return None
+
+    def _request_body_size_bytes(self, request):
+        try:
+            value = request.META.get('CONTENT_LENGTH')
+            if value in (None, ''):
+                return 0
+            size = int(value)
+            return size if size >= 0 else None
+        except Exception:
+            return None
+
+    def _response_body_size_bytes(self, response):
+        if getattr(response, 'streaming', False):
+            return None
+        try:
+            value = response.get('content-length')
+            if value not in (None, ''):
+                size = int(value)
+                return size if size >= 0 else None
+        except Exception:
+            pass
+        try:
+            return len(response.content)
+        except Exception:
+            return None
+
+    def _is_slow_request(self, execution_time):
+        threshold = metrics_settings.slow_request_threshold_seconds()
+        if threshold is None:
+            return False
+        return execution_time >= threshold
+
+    def _active_metric_labels(self, state):
+        labels = state.get('metrics_low_cardinality', {}).copy()
+        labels['method'] = state.get('method', 'unknown')
+        return labels
+
+    def _record_active_request_start(self, state):
+        if not metrics_settings.api_metrics_enabled():
+            return
+        try:
+            get_recorder().increment_active_requests(self._active_metric_labels(state))
+            state['active_request_recorded'] = True
+        except Exception:
+            state['active_request_recorded'] = False
+
+    def _record_active_request_end(self, state):
+        if not state.get('active_request_recorded'):
+            return
+        try:
+            get_recorder().decrement_active_requests(self._active_metric_labels(state))
+        except Exception:
+            pass
+        finally:
+            state['active_request_recorded'] = False
+
+    def _record_exception_metrics(self, exception, state):
+        if not metrics_settings.api_metrics_enabled():
+            return
+        labels = state.get('metrics_low_cardinality', {})
+        event = {
+            'method': state.get('method'),
+            'status_code': 500,
+            'exception_class': exception.__class__.__name__,
+            'execution_time': time.time() - state['start_time'],
+            'low_cardinality': labels.copy(),
+        }
+        try:
+            get_recorder().increment_http_exception(event)
+        except Exception:
+            pass
+
+    def _actor_fingerprint(self, request):
+        if not metrics_settings.security_metrics_enabled():
+            return None
+        config = metrics_settings.security_actor_tracking_config()
+        if not config.get('enabled', True):
+            return None
+        parts = []
+        user = getattr(request, 'user', None)
+        if config.get('include_user_id', True) and getattr(user, 'is_authenticated', False):
+            user_id = getattr(user, 'pk', None)
+            if user_id is not None:
+                parts.append('user:{}'.format(user_id))
+        if config.get('include_ip', True):
+            ip = get_client_ip(request)
+            if ip:
+                parts.append('ip:{}'.format(ip))
+        if config.get('include_user_agent_family', True):
+            user_agent = str(request.META.get('HTTP_USER_AGENT', '')).split('/', 1)[0].strip()
+            if user_agent:
+                parts.append('ua:{}'.format(user_agent[:64]))
+        if not parts:
+            return None
+        secret = str(getattr(settings, 'SECRET_KEY', 'drf-api-logger')).encode('utf-8')
+        message = '|'.join(parts).encode('utf-8', errors='ignore')
+        return hmac.new(secret, message, hashlib.sha256).hexdigest()[:32]
+
+    def _business_context(self, request, response=None, exception=None):
+        getter = metrics_settings.security_context_getter()
+        if getter is None:
+            return {}
+        try:
+            return sanitize_business_context(
+                getter(request, response=response, exception=exception)
+            )
+        except Exception:
+            return {}
+
+    def _metrics_low_cardinality(self, state, response=None, status_code=None):
+        low_cardinality = state.get('low_cardinality') or {}
+        if status_code is None and response is not None:
+            status_code = getattr(response, 'status_code', None)
+        derived = build_low_cardinality_from_resolver(
+            state.get('resolver_match'),
+            status_code,
+        )
+        merged = derived.copy()
+        for key, value in low_cardinality.items():
+            if key == 'status_class' and value == metrics_settings.UNKNOWN_LABEL_VALUE:
+                continue
+            if key == 'route' and value == metrics_settings.UNKNOWN_LABEL_VALUE and derived.get('route'):
+                continue
+            if key == 'view_name' and value == metrics_settings.UNKNOWN_LABEL_VALUE and derived.get('view_name'):
+                continue
+            merged[key] = value
+        if not merged.get('status_class') or merged.get('status_class') == metrics_settings.UNKNOWN_LABEL_VALUE:
+            merged['status_class'] = derived.get('status_class', metrics_settings.UNKNOWN_LABEL_VALUE)
+        return merged
+
+    def _record_http_metrics(self, request, response, state):
+        if not metrics_settings.api_metrics_enabled():
+            return
+        execution_time = time.time() - state['start_time']
+        event = {
+            'method': state['method'],
+            'status_code': getattr(response, 'status_code', None),
+            'execution_time': execution_time,
+            'request_body_size_bytes': state.get('request_body_size_bytes'),
+            'response_body_size_bytes': self._response_body_size_bytes(response),
+            'is_slow': self._is_slow_request(execution_time),
+            'throttle_scope': getattr(request, 'throttle_scope', 'unknown'),
+            'low_cardinality': state.get('metrics_low_cardinality', {}),
+        }
+        try:
+            get_recorder().observe_http_request(event)
+        except Exception:
+            return
+
+    def _record_security_metrics(self, request, response, state, exception=None):
+        if not metrics_settings.security_metrics_enabled():
+            return
+        labels = state.get('metrics_low_cardinality', {})
+        detection_start = time.perf_counter()
+        recorder = get_recorder()
+        status_code = getattr(response, 'status_code', None) if response is not None else 500
+        try:
+            context = SecurityContext(
+                request=request,
+                response=response,
+                exception=exception,
+                route=labels.get('route', 'unknown'),
+                method=state['method'],
+                status_code=status_code,
+                status_class=labels.get('status_class', 'unknown'),
+                request_body_sample=state.get('request_body_sample'),
+                response_body_sample=self._get_response_body_sample(response) if response is not None else None,
+                actor_fingerprint=state.get('actor_fingerprint'),
+                low_cardinality=labels.copy(),
+                business_context=self._business_context(request, response=response, exception=exception),
+            )
+            def record_error(rule_id, exc):
+                recorder.increment_security_detection_error(rule_id, exc.__class__.__name__)
+
+            for signal in evaluate_security_signals(context, error_callback=record_error):
+                recorder.observe_security_event(signal)
+        except Exception as exc:
+            try:
+                recorder.increment_security_detection_error('unknown', exc.__class__.__name__)
+            except Exception:
+                return
+        finally:
+            try:
+                recorder.observe_security_detection(
+                    {'route': labels.get('route', 'unknown')},
+                    time.perf_counter() - detection_start,
+                )
+            except Exception:
+                return
 
     def _prepare_log_state(self, request):
         resolver_match, url_name, namespace = self._resolve_request(request)
@@ -349,14 +590,26 @@ class APILoggerMiddleware:
         start_time = time.time()
         middleware_before_start = time.time()
         headers = get_headers(request=request)
-        request_data = self._get_request_data(request)
+        request_data = ''
+        if self._api_logger_storage_enabled():
+            payload_start = time.perf_counter()
+            request_data = self._get_request_data(request)
+            try:
+                get_recorder().observe_payload_capture(
+                    {'location': 'request'},
+                    'request',
+                    time.perf_counter() - payload_start,
+                )
+            except Exception:
+                pass
+        request_body_sample = self._get_request_body_sample(request)
         tracing_id = self._build_tracing_id(headers)
         if tracing_id:
             request.tracing_id = tracing_id
         middleware_before_end = time.time()
 
         correlation_context = {}
-        low_cardinality = {}
+        low_cardinality = build_low_cardinality_from_resolver(resolver_match)
         logging_context_set = False
         if self.DRF_API_LOGGER_ENABLE_CORRELATION:
             correlation_context = build_correlation_context(
@@ -380,14 +633,21 @@ class APILoggerMiddleware:
             'headers': headers,
             'method': request.method,
             'request_data': request_data,
+            'request_body_sample': request_body_sample,
+            'request_body_size_bytes': self._request_body_size_bytes(request),
+            'actor_fingerprint': self._actor_fingerprint(request),
             'tracing_id': tracing_id,
             'correlation_context': correlation_context,
             'low_cardinality': low_cardinality,
+            'metrics_low_cardinality': low_cardinality.copy(),
             'logging_context_set': logging_context_set,
             'profile_this_request': profile_this_request,
             'sql_profiling': self._start_sql_profiling(profile_this_request),
             'sql_data': None,
             'view_end': None,
+            'active_request_recorded': False,
+            'profiling_payload': None,
+            'profiling_metrics_recorded': False,
         }
 
     def _finish_log_state_after_view(self, state, view_start):
@@ -414,34 +674,45 @@ class APILoggerMiddleware:
         return datetime.now()
 
     def _build_log_data(self, request, response, state, policy_decision, policy_payload):
-        return dict(
-            api=mask_sensitive_data(
-                self._policy_api(policy_decision, request, self._request_api(request)),
-                mask_api_parameters=True,
-                extra_sensitive_keys=policy_decision.mask_keys,
-            ),
-            headers=mask_sensitive_data(
-                policy_payload['headers'],
-                extra_sensitive_keys=policy_decision.mask_keys,
-            ),
-            body=mask_sensitive_data(
-                policy_payload['request_data'],
-                extra_sensitive_keys=policy_decision.mask_keys,
-            ),
-            method=state['method'],
-            client_ip_address=get_client_ip(request),
-            response=mask_sensitive_data(
-                policy_payload['response_body'],
-                extra_sensitive_keys=policy_decision.mask_keys,
-            ),
-            status_code=response.status_code,
-            execution_time=time.time() - state['start_time'],
-            added_on=self._current_time(),
-        )
+        masking_start = time.perf_counter()
+        try:
+            return dict(
+                api=mask_sensitive_data(
+                    self._policy_api(policy_decision, request, self._request_api(request)),
+                    mask_api_parameters=True,
+                    extra_sensitive_keys=policy_decision.mask_keys,
+                ),
+                headers=mask_sensitive_data(
+                    policy_payload['headers'],
+                    extra_sensitive_keys=policy_decision.mask_keys,
+                ),
+                body=mask_sensitive_data(
+                    policy_payload['request_data'],
+                    extra_sensitive_keys=policy_decision.mask_keys,
+                ),
+                method=state['method'],
+                client_ip_address=get_client_ip(request),
+                response=mask_sensitive_data(
+                    policy_payload['response_body'],
+                    extra_sensitive_keys=policy_decision.mask_keys,
+                ),
+                status_code=response.status_code,
+                execution_time=time.time() - state['start_time'],
+                added_on=self._current_time(),
+            )
+        finally:
+            try:
+                get_recorder().observe_masking(
+                    {'location': 'log_event'},
+                    'log_event',
+                    time.perf_counter() - masking_start,
+                )
+            except Exception:
+                pass
 
-    def _add_profiling_data(self, data, state, middleware_after_start):
+    def _build_profiling_payload(self, state, middleware_after_start):
         if not state['profile_this_request']:
-            return
+            return None
         sql_data = state['sql_data']
         profiling = {
             'middleware_before_view': round(
@@ -454,31 +725,62 @@ class APILoggerMiddleware:
         }
         if sql_data:
             profiling['sql'] = sql_data
+        return profiling
+
+    def _record_profiling_metrics(self, state, profiling):
+        if not profiling or state.get('profiling_metrics_recorded'):
+            return
+        labels = state.get('metrics_low_cardinality', {}).copy()
+        try:
+            get_recorder().observe_profiling(labels, profiling)
+            state['profiling_metrics_recorded'] = True
+        except Exception:
+            pass
+
+    def _add_profiling_data(self, data, state, middleware_after_start):
+        if not state['profile_this_request']:
+            return
+        profiling = state.get('profiling_payload')
+        if profiling is None:
+            profiling = self._build_profiling_payload(state, middleware_after_start)
+            state['profiling_payload'] = profiling
+            self._record_profiling_metrics(state, profiling)
+        sql_data = state['sql_data']
         data['profiling_data'] = profiling
         data['sql_query_count'] = sql_data['query_count'] if sql_data else None
 
     def _database_payload(self, data, request_data):
+        serialization_start = time.perf_counter()
         database_data = data.copy()
-        database_data['headers'] = (
-            json.dumps(database_data['headers'], indent=4, ensure_ascii=False)
-            if database_data.get('headers') else ''
-        )
-        if request_data:
-            database_data['body'] = (
-                json.dumps(database_data['body'], indent=4, ensure_ascii=False)
-                if database_data.get('body') else ''
+        try:
+            database_data['headers'] = (
+                json.dumps(database_data['headers'], indent=4, ensure_ascii=False)
+                if database_data.get('headers') else ''
             )
-        database_data['response'] = (
-            json.dumps(database_data['response'], indent=4, ensure_ascii=False)
-            if database_data.get('response') else ''
-        )
-        if database_data.get('profiling_data'):
-            database_data['profiling_data'] = json.dumps(
-                database_data['profiling_data'],
-                indent=4,
-                ensure_ascii=False,
+            if request_data:
+                database_data['body'] = (
+                    json.dumps(database_data['body'], indent=4, ensure_ascii=False)
+                    if database_data.get('body') else ''
+                )
+            database_data['response'] = (
+                json.dumps(database_data['response'], indent=4, ensure_ascii=False)
+                if database_data.get('response') else ''
             )
-        return database_data
+            if database_data.get('profiling_data'):
+                database_data['profiling_data'] = json.dumps(
+                    database_data['profiling_data'],
+                    indent=4,
+                    ensure_ascii=False,
+                )
+            return database_data
+        finally:
+            try:
+                get_recorder().observe_serialization(
+                    {'payload': 'database_log'},
+                    time.perf_counter() - serialization_start,
+                )
+            except Exception:
+                pass
 
     def _emit_log_data(self, data, state, policy_decision):
         if policy_decision.database and self.DRF_API_LOGGER_DATABASE and logger_apps.LOGGER_THREAD:
@@ -501,49 +803,79 @@ class APILoggerMiddleware:
             API_LOGGER_SIGNAL.listen(**signal_data)
 
     def _finalize_log_response(self, request, response, state):
-        if self.DRF_API_LOGGER_STATUS_CODES and response.status_code not in self.DRF_API_LOGGER_STATUS_CODES:
-            return response
-        if len(self.DRF_API_LOGGER_METHODS) > 0 and state['method'] not in self.DRF_API_LOGGER_METHODS:
-            return response
-        if not self._should_log_response_content_type(response):
-            return response
+        try:
+            logger_overhead_start = time.perf_counter()
+            if self.DRF_API_LOGGER_ENABLE_CORRELATION:
+                state['correlation_context'] = build_correlation_context(
+                    request=request,
+                    headers=state['headers'],
+                    resolver_match=state['resolver_match'],
+                    status_code=response.status_code,
+                    tracing_id=state['tracing_id'],
+                )
+                state['low_cardinality'] = self._attach_correlation_context(
+                    request,
+                    state['correlation_context'],
+                )
 
-        response_body = self._get_response_body(response)
-        middleware_after_start = time.time()
+            state['metrics_low_cardinality'] = self._metrics_low_cardinality(state, response)
+            self._record_http_metrics(request, response, state)
+            self._record_security_metrics(request, response, state)
 
-        if self.DRF_API_LOGGER_ENABLE_CORRELATION:
-            state['correlation_context'] = build_correlation_context(
+            middleware_after_start = time.time()
+            if state['profile_this_request']:
+                profiling = self._build_profiling_payload(state, middleware_after_start)
+                state['profiling_payload'] = profiling
+                self._record_profiling_metrics(state, profiling)
+
+            if not self._api_logger_storage_enabled():
+                return response
+
+            if self.DRF_API_LOGGER_STATUS_CODES and response.status_code not in self.DRF_API_LOGGER_STATUS_CODES:
+                return response
+            if len(self.DRF_API_LOGGER_METHODS) > 0 and state['method'] not in self.DRF_API_LOGGER_METHODS:
+                return response
+            if not self._should_log_response_content_type(response):
+                return response
+
+            response_body = self._get_response_body(response)
+
+            policy_decision = safe_evaluate_logging_policy(
                 request=request,
-                headers=state['headers'],
+                response=response,
                 resolver_match=state['resolver_match'],
-                status_code=response.status_code,
-                tracing_id=state['tracing_id'],
+                correlation_context=state['correlation_context'],
+                low_cardinality=state['low_cardinality'],
             )
-            state['low_cardinality'] = self._attach_correlation_context(
-                request,
-                state['correlation_context'],
-            )
+            if not policy_decision.log:
+                try:
+                    get_recorder().increment_skipped_logs(policy_decision.reason)
+                except Exception:
+                    pass
+                return response
 
-        policy_decision = safe_evaluate_logging_policy(
-            request=request,
-            response=response,
-            resolver_match=state['resolver_match'],
-            correlation_context=state['correlation_context'],
-            low_cardinality=state['low_cardinality'],
-        )
-        if not policy_decision.log:
+            policy_payload = self._policy_payload(
+                policy_decision,
+                state['headers'],
+                state['request_data'],
+                response_body,
+            )
+            data = self._build_log_data(request, response, state, policy_decision, policy_payload)
+            self._add_profiling_data(data, state, middleware_after_start)
+            self._emit_log_data(data, state, policy_decision)
+            try:
+                get_recorder().observe_logger_overhead(
+                    {
+                        'route': state['metrics_low_cardinality'].get('route', 'unknown'),
+                        'logging_enabled': 'true',
+                    },
+                    time.perf_counter() - logger_overhead_start,
+                )
+            except Exception:
+                pass
             return response
-
-        policy_payload = self._policy_payload(
-            policy_decision,
-            state['headers'],
-            state['request_data'],
-            response_body,
-        )
-        data = self._build_log_data(request, response, state, policy_decision, policy_payload)
-        self._add_profiling_data(data, state, middleware_after_start)
-        self._emit_log_data(data, state, policy_decision)
-        return response
+        finally:
+            self._record_active_request_end(state)
 
     def __call__(self, request):
         if self.async_mode:
@@ -557,11 +889,18 @@ class APILoggerMiddleware:
         if state is None:
             return self.get_response(request)
 
+        self._record_active_request_start(state)
         state['view_start'] = time.time()
         try:
             response = self.get_response(request)
-        finally:
+        except Exception as exc:
             self._finish_log_state_after_view(state, state['view_start'])
+            state['metrics_low_cardinality'] = self._metrics_low_cardinality(state, status_code=500)
+            self._record_exception_metrics(exc, state)
+            self._record_security_metrics(request, None, state, exception=exc)
+            self._record_active_request_end(state)
+            raise
+        self._finish_log_state_after_view(state, state['view_start'])
         return self._finalize_log_response(request, response, state)
 
     async def __acall__(self, request):
@@ -574,9 +913,16 @@ class APILoggerMiddleware:
         if state is None:
             return await self.get_response(request)
 
+        self._record_active_request_start(state)
         state['view_start'] = time.time()
         try:
             response = await self.get_response(request)
-        finally:
+        except Exception as exc:
             self._finish_log_state_after_view(state, state['view_start'])
+            state['metrics_low_cardinality'] = self._metrics_low_cardinality(state, status_code=500)
+            self._record_exception_metrics(exc, state)
+            self._record_security_metrics(request, None, state, exception=exc)
+            self._record_active_request_end(state)
+            raise
+        self._finish_log_state_after_view(state, state['view_start'])
         return self._finalize_log_response(request, response, state)

--- a/llms.txt
+++ b/llms.txt
@@ -104,6 +104,35 @@ API_LOGGER_SIGNAL.listen += export_observability
 
 Observability helpers are dependency-free adapters. The application owns prometheus-client, OpenTelemetry, Sentry SDK, scrape endpoints, collectors, DSNs, and credentials. Prometheus labels are low-cardinality: route, url_name, app_name, namespace, status_class, and method only. Do not put request_id, trace_id, actor_id, tenant_id, api_consumer_id, client_id, headers, bodies, cookies, authorization values, tokens, emails, usernames, or direct customer identifiers in metrics labels.
 
+Optional first-party metrics:
+
+```python
+DRF_API_LOGGER_METRICS_ENABLED = True
+DRF_API_LOGGER_METRICS_GROUPS = ["logger", "pipeline"]
+DRF_API_LOGGER_API_METRICS_ENABLED = False
+```
+
+Install `drf-api-logger[prometheus]` before enabling the Prometheus exporter. Keep API metrics disabled when the application already has Django or OpenTelemetry HTTP instrumentation. If enabling the package metrics endpoint, mount `drf_api_logger.metrics.urls` only under an internal protected path. Do not expose it publicly.
+
+First-party metrics cover logger overhead, payload capture, masking, serialization, enqueue duration, queue depth, queue utilization, worker state, flush duration, storage write duration/failures, optional API request count/duration/active requests/body sizes/slow requests/exceptions/throttles, and optional profiling summaries for SQL duration, query count, duplicate query count, likely N+1 patterns, view duration, and middleware duration.
+
+Optional security signals:
+
+```python
+DRF_API_LOGGER_SECURITY_METRICS_ENABLED = True
+DRF_API_LOGGER_SECURITY_MODE = "detect"
+DRF_API_LOGGER_SECURITY_BODY_INSPECTION = {
+    "enabled": True,
+    "max_body_bytes": 8192,
+    "inspect_request_body": True,
+    "inspect_response_body": False,
+}
+```
+
+Security signals are detect-only and are not a WAF, IDS, SIEM, API gateway, rate limiter, or fraud engine. They must never use request bodies, response bodies, raw URLs, query strings, tokens, request IDs, trace IDs, user IDs, IP addresses, object IDs, SQL queries, or exception messages as labels.
+
+Security rules DRFSEC-001 through DRFSEC-016 cover auth failures, success after failures, token failures, authorization failures, admin/debug probes, payload attack patterns, rate-limit pressure, route scans, object enumeration hints, log injection, sensitive response-field hints, pagination sweeps, bulk exports, high response volume, sensitive business routes, and repeated business-flow actions. Actor correlation uses bounded process-local state and internal HMAC fingerprints only.
+
 Policy controls:
 Use DRF_API_LOGGER_POLICY for endpoint-specific logging decisions. Recommend log: False for health checks or endpoints that must not produce database rows or signal exports. Recommend request_body: False, response_body: False, headers: False, and mask_keys for sensitive payloads. Recommend signal: False when API_LOGGER_SIGNAL listeners export to external systems and an endpoint should remain local. Do not put secrets, tokens, emails, usernames, direct customer identifiers, headers, request bodies, or response bodies in policy reasons.
 
@@ -132,6 +161,8 @@ Good prompts for AI assistants:
 - Add request tracing to DRF API logs using drf-api-logger.
 - Add request correlation to signals and application logs using drf-api-logger without a migration.
 - Add safe Prometheus, OpenTelemetry, or Sentry integration to DRF API Logger signals without exporting request bodies or high-cardinality metric labels.
+- Add optional DRF API Logger health metrics with safe low-cardinality Prometheus labels.
+- Add detect-only suspicious API activity metrics without blocking requests.
 - Schedule retention pruning for drf-api-logger database rows.
 
 Anti-patterns:
@@ -139,11 +170,15 @@ Anti-patterns:
 - Do not show unlimited body logging for production systems.
 - Do not show examples containing direct identities, real customer data, real secrets, private keys, or session cookies.
 - Do not put request IDs, trace IDs, direct identities, tokens, headers, request bodies, or response bodies into Prometheus labels or external observability exports.
+- Do not expose the optional DRF API Logger metrics endpoint publicly.
+- Do not describe DRF API Logger security signals as blocking protection or as a replacement for WAF, SIEM, IDS, gateway, or rate-limit tooling.
 - Do not describe DRF API Logger as a replacement for metrics, distributed tracing, exception monitoring, uptime monitoring, or SIEM tooling.
 
 Useful docs:
 - README: https://github.com/vishalanandl177/DRF-API-Logger#readme
 - Safe observability integrations: https://github.com/vishalanandl177/DRF-API-Logger/blob/main/docs/observability_integrations.rst
+- Metrics: https://github.com/vishalanandl177/DRF-API-Logger/blob/main/docs/metrics.rst
+- Security signals: https://github.com/vishalanandl177/DRF-API-Logger/blob/main/docs/security_signals.rst
 - Operations guide: https://github.com/vishalanandl177/DRF-API-Logger/blob/main/docs/operations.rst
 - Compliance guide: https://github.com/vishalanandl177/DRF-API-Logger/blob/main/docs/compliance.rst
 - Developer testing guide: https://github.com/vishalanandl177/DRF-API-Logger/blob/main/docs/developer_testing.rst

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def get_long_desc():
 
 setuptools.setup(
     name="drf-api-logger",
-    version="1.3.0",
+    version="1.4.0",
     author="Vishal Anand",
     author_email="vishalanandl177@gmail.com",
     description="The production standard for DRF API observability: request/response logging, profiling, masking, and admin analytics.",
@@ -24,6 +24,9 @@ setuptools.setup(
         "djangorestframework>=3.16",
         "bleach>=3.1.5",
     ],
+    extras_require={
+        "prometheus": ["prometheus-client>=0.20"],
+    },
     license="Apache-2.0",
     python_requires='>=3.10',
     project_urls={

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,7 @@ This directory contains the package test suite.
 - `test_asgi_middleware.py`: ASGI middleware capability, AsyncClient integration, async logging, and context isolation.
 - `test_models.py`: database model and Django admin behavior.
 - `test_signals.py`: event listeners, background queue processing, app startup, and worker stats.
+- `test_metrics.py`: optional metrics settings, safe labels, no-op recorder, system checks, middleware hooks, queue metrics, security signals, and endpoint safety.
 - `test_profiling.py`: profiling settings, SQL tracking, admin display, and diagnosis rules.
 - `test_backward_compat.py`: default behavior and payload compatibility.
 - `test_integration.py`: end-to-end middleware, signal, and database flows.

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -323,11 +323,12 @@ class TestObservabilityCompatibility(TestCase):
 
     def test_observability_helpers_do_not_add_runtime_dependencies(self):
         setup_text = Path(__file__).resolve().parents[1].joinpath("setup.py").read_text(encoding="utf-8")
+        install_requires = setup_text.split("install_requires=[", 1)[1].split("]", 1)[0]
 
-        self.assertNotIn("prometheus-client", setup_text)
-        self.assertNotIn("opentelemetry-api", setup_text)
-        self.assertNotIn("opentelemetry-sdk", setup_text)
-        self.assertNotIn("sentry-sdk", setup_text)
+        self.assertNotIn("prometheus-client", install_requires)
+        self.assertNotIn("opentelemetry-api", install_requires)
+        self.assertNotIn("opentelemetry-sdk", install_requires)
+        self.assertNotIn("sentry-sdk", install_requires)
 
     @override_settings(
         DRF_API_LOGGER_DATABASE=True,
@@ -377,12 +378,13 @@ class TestPolicyCompatibility(TestCase):
 
     def test_policy_helpers_do_not_add_runtime_dependencies(self):
         setup_text = Path(__file__).resolve().parents[1].joinpath("setup.py").read_text(encoding="utf-8")
+        install_requires = setup_text.split("install_requires=[", 1)[1].split("]", 1)[0]
 
-        self.assertNotIn("prometheus-client", setup_text)
-        self.assertNotIn("opentelemetry-api", setup_text)
-        self.assertNotIn("opentelemetry-sdk", setup_text)
-        self.assertNotIn("sentry-sdk", setup_text)
-        self.assertNotIn("celery", setup_text)
+        self.assertNotIn("prometheus-client", install_requires)
+        self.assertNotIn("opentelemetry-api", install_requires)
+        self.assertNotIn("opentelemetry-sdk", install_requires)
+        self.assertNotIn("sentry-sdk", install_requires)
+        self.assertNotIn("celery", install_requires)
 
     @override_settings(
         DRF_API_LOGGER_DATABASE=True,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,898 @@
+import json
+import sys
+import types
+from unittest.mock import Mock, patch
+
+from django.core.checks import ERROR, WARNING
+from django.http import Http404, HttpResponse
+from django.test import RequestFactory, TestCase
+from django.test.utils import override_settings
+from django.urls import Resolver404
+from django.utils import timezone
+
+from drf_api_logger.middleware.api_logger_middleware import APILoggerMiddleware
+
+
+class FakeRecorder:
+    def __init__(self):
+        self.calls = []
+
+    def observe_http_request(self, event):
+        self.calls.append(("observe_http_request", event.copy()))
+
+    def increment_active_requests(self, labels):
+        self.calls.append(("increment_active_requests", labels.copy()))
+
+    def decrement_active_requests(self, labels):
+        self.calls.append(("decrement_active_requests", labels.copy()))
+
+    def increment_http_exception(self, event):
+        self.calls.append(("increment_http_exception", event.copy()))
+
+    def observe_logger_overhead(self, labels, duration_seconds):
+        self.calls.append(("observe_logger_overhead", labels.copy(), duration_seconds))
+
+    def observe_payload_capture(self, labels, location, duration_seconds):
+        self.calls.append(("observe_payload_capture", labels.copy(), location, duration_seconds))
+
+    def observe_masking(self, labels, location, duration_seconds):
+        self.calls.append(("observe_masking", labels.copy(), location, duration_seconds))
+
+    def observe_serialization(self, labels, duration_seconds):
+        self.calls.append(("observe_serialization", labels.copy(), duration_seconds))
+
+    def observe_enqueue(self, labels, duration_seconds):
+        self.calls.append(("observe_enqueue", labels.copy(), duration_seconds))
+
+    def increment_enqueued_logs(self, queue_name="default"):
+        self.calls.append(("increment_enqueued_logs", queue_name))
+
+    def increment_processed_logs(self, storage_backend, count):
+        self.calls.append(("increment_processed_logs", storage_backend, count))
+
+    def increment_dropped_logs(self, reason):
+        self.calls.append(("increment_dropped_logs", reason))
+
+    def increment_storage_write_failure(self, storage_backend, exception_class):
+        self.calls.append(("increment_storage_write_failure", storage_backend, exception_class))
+
+    def set_queue_depth(self, queue_name, depth):
+        self.calls.append(("set_queue_depth", queue_name, depth))
+
+    def set_queue_capacity(self, queue_name, capacity):
+        self.calls.append(("set_queue_capacity", queue_name, capacity))
+
+    def set_queue_utilization(self, queue_name, ratio):
+        self.calls.append(("set_queue_utilization", queue_name, ratio))
+
+    def set_worker_up(self, worker_name, up):
+        self.calls.append(("set_worker_up", worker_name, up))
+
+    def increment_worker_restart(self, worker_name):
+        self.calls.append(("increment_worker_restart", worker_name))
+
+    def observe_flush(self, storage_backend, duration_seconds, batch_size):
+        self.calls.append(("observe_flush", storage_backend, duration_seconds, batch_size))
+
+    def observe_storage_write(self, storage_backend, duration_seconds):
+        self.calls.append(("observe_storage_write", storage_backend, duration_seconds))
+
+    def observe_profiling(self, labels, profiling):
+        self.calls.append(("observe_profiling", labels.copy(), profiling.copy()))
+
+    def observe_security_event(self, signal):
+        self.calls.append(("observe_security_event", signal))
+
+    def observe_security_detection(self, labels, duration_seconds):
+        self.calls.append(("observe_security_detection", labels.copy(), duration_seconds))
+
+    def increment_security_detection_error(self, rule_id, exception_class):
+        self.calls.append(("increment_security_detection_error", rule_id, exception_class))
+
+
+class MetricsSettingsAndLabelsTests(TestCase):
+    @override_settings(DRF_API_LOGGER_METRICS_ENABLED=False)
+    def test_disabled_metrics_return_noop_recorder(self):
+        from drf_api_logger.metrics.recorder import get_recorder
+
+        recorder = get_recorder()
+
+        self.assertEqual(recorder.__class__.__name__, "NoOpMetricsRecorder")
+        with recorder.timer("payload_capture", labels={"location": "request"}):
+            pass
+
+    @override_settings(
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="prometheus",
+    )
+    @patch(
+        "drf_api_logger.metrics.prometheus.get_prometheus_recorder",
+        side_effect=ImportError("missing prometheus_client"),
+    )
+    def test_missing_prometheus_runtime_returns_noop_recorder(self, mock_prometheus):
+        from drf_api_logger.metrics.recorder import get_recorder
+
+        recorder = get_recorder()
+
+        self.assertEqual(recorder.__class__.__name__, "NoOpMetricsRecorder")
+
+    @override_settings(
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_API_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_LABELS=[
+            "method",
+            "route",
+            "status_class",
+            "request_id",
+            "client_ip",
+        ],
+    )
+    def test_metric_label_builder_rejects_unsafe_configured_labels(self):
+        from drf_api_logger.metrics.labels import build_http_labels
+
+        labels = build_http_labels(
+            {
+                "method": "get",
+                "status_code": 200,
+                "raw_path": "/api/users/123/?token=secret",
+                "client_ip": "203.0.113.20",
+                "request_id": "req-123",
+                "low_cardinality": {
+                    "route": "api/users/<int:pk>/",
+                    "status_class": "2xx",
+                },
+            }
+        )
+
+        self.assertEqual(labels["method"], "GET")
+        self.assertEqual(labels["route"], "api/users/<int:pk>/")
+        self.assertEqual(labels["status_class"], "2xx")
+        self.assertNotIn("request_id", labels)
+        self.assertNotIn("client_ip", labels)
+        self.assertNotIn("raw_path", labels)
+
+    def test_security_label_builder_uses_only_low_cardinality_values(self):
+        from drf_api_logger.metrics.labels import build_security_labels
+        from drf_api_logger.metrics.security import SecuritySignal
+
+        signal = SecuritySignal(
+            rule_id="DRFSEC-001",
+            event_type="auth_failure",
+            category="authentication",
+            severity="warning",
+            score=3,
+            route="/api/private/123/",
+            method="post",
+            status_class="4xx",
+            outcome="observed",
+            reason="bad password for developer@example.invalid",
+        )
+
+        labels = build_security_labels(signal)
+
+        self.assertEqual(labels["rule_id"], "DRFSEC-001")
+        self.assertEqual(labels["category"], "authentication")
+        self.assertEqual(labels["severity"], "warning")
+        self.assertEqual(labels["route"], "/api/private/123/")
+        self.assertEqual(labels["method"], "POST")
+        self.assertEqual(labels["status_class"], "4xx")
+        self.assertEqual(labels["reason"], "unknown")
+
+    def test_unresolved_routes_use_low_cardinality_unresolved_labels(self):
+        from drf_api_logger.metrics.labels import build_low_cardinality_from_resolver
+
+        labels = build_low_cardinality_from_resolver(None, status_code=404)
+
+        self.assertEqual(labels["route"], "unresolved")
+        self.assertEqual(labels["view_name"], "unresolved")
+        self.assertEqual(labels["status_class"], "4xx")
+
+
+class OptionalPrometheusRecorderTests(TestCase):
+    def fake_prometheus_module(self):
+        module = types.ModuleType("prometheus_client")
+
+        class FakeCollectorRegistry:
+            pass
+
+        class FakeMetric:
+            instances = []
+
+            def __init__(self, *args, **kwargs):
+                self.calls = []
+                FakeMetric.instances.append(self)
+
+            def labels(self, **labels):
+                self.calls.append(("labels", labels))
+                return self
+
+            def inc(self, amount=1):
+                self.calls.append(("inc", amount))
+
+            def dec(self, amount=1):
+                self.calls.append(("dec", amount))
+
+            def observe(self, value):
+                self.calls.append(("observe", value))
+
+            def set(self, value):
+                self.calls.append(("set", value))
+
+        module.Counter = FakeMetric
+        module.Gauge = FakeMetric
+        module.Histogram = FakeMetric
+        module.CollectorRegistry = FakeCollectorRegistry
+        module.generate_latest = lambda registry: b"# fake metrics\n"
+        module.FakeMetric = FakeMetric
+        return module
+
+    @override_settings(
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_API_METRICS_ENABLED=True,
+        DRF_API_LOGGER_SECURITY_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="prometheus",
+        DRF_API_LOGGER_METRICS_GROUPS=["logger", "pipeline", "profiling"],
+    )
+    def test_prometheus_recorder_records_supported_metric_groups_with_fake_client(self):
+        fake_module = self.fake_prometheus_module()
+        with patch.dict(sys.modules, {"prometheus_client": fake_module}):
+            from drf_api_logger.metrics.prometheus import (
+                generate_prometheus_latest,
+                get_prometheus_recorder,
+                reset_prometheus_recorder_for_tests,
+            )
+            from drf_api_logger.metrics.security import SecuritySignal
+
+            reset_prometheus_recorder_for_tests()
+            recorder = get_prometheus_recorder()
+
+            recorder.increment_active_requests({"method": "GET", "route": "api/test/"})
+            recorder.observe_http_request(
+                {
+                    "method": "GET",
+                    "status_code": 200,
+                    "execution_time": 0.05,
+                    "request_body_size_bytes": 10,
+                    "response_body_size_bytes": 20,
+                    "is_slow": True,
+                    "low_cardinality": {
+                        "route": "api/test/",
+                        "view_name": "tests.view",
+                        "status_class": "2xx",
+                    },
+                }
+            )
+            recorder.decrement_active_requests({"method": "GET", "route": "api/test/"})
+            recorder.increment_http_exception(
+                {
+                    "status_code": 500,
+                    "exception_class": "ValueError",
+                    "low_cardinality": {"route": "api/test/"},
+                }
+            )
+            recorder.observe_logger_overhead(
+                {"route": "api/test/", "logging_enabled": "true"},
+                0.001,
+            )
+            recorder.observe_payload_capture({"location": "request"}, "request", 0.001)
+            recorder.observe_masking({"location": "log_event"}, "log_event", 0.001)
+            recorder.observe_serialization({"payload": "database_log"}, 0.001)
+            recorder.observe_enqueue({"queue_name": "database"}, 0.001)
+            recorder.increment_enqueued_logs("database")
+            recorder.increment_processed_logs("database", 2)
+            recorder.increment_dropped_logs("queue_error")
+            recorder.increment_skipped_logs("policy")
+            recorder.increment_storage_write_failure("database", "OperationalError")
+            recorder.set_queue_depth("database", 3)
+            recorder.set_queue_capacity("database", 50)
+            recorder.set_queue_utilization("database", 0.06)
+            recorder.set_worker_up("insert_log_into_database", True)
+            recorder.increment_worker_restart("insert_log_into_database")
+            recorder.observe_flush("database", 0.002, 2)
+            recorder.observe_storage_write("database", 0.002)
+            recorder.observe_profiling(
+                {"route": "api/test/", "view_name": "tests.view"},
+                {
+                    "middleware_before_view": 0.001,
+                    "view_and_serialization": 0.1,
+                    "middleware_after_view": 0.001,
+                    "sql": {
+                        "total_time": 0.08,
+                        "query_count": 12,
+                        "duplicate_query_count": 4,
+                    },
+                },
+            )
+            recorder.observe_security_event(
+                SecuritySignal(
+                    rule_id="DRFSEC-001",
+                    event_type="auth_failure",
+                    category="authentication",
+                    severity="warning",
+                    score=3,
+                    route="api/login/",
+                    method="POST",
+                    status_class="4xx",
+                )
+            )
+            recorder.observe_security_detection({"route": "api/login/"}, 0.001)
+            recorder.increment_security_detection_error("DRFSEC-001", "RuntimeError")
+
+            self.assertEqual(generate_prometheus_latest(), b"# fake metrics\n")
+            self.assertTrue(
+                any(call[0] in {"inc", "observe", "set"} for metric in fake_module.FakeMetric.instances for call in metric.calls)
+            )
+            reset_prometheus_recorder_for_tests()
+
+
+class MetricsStateTests(TestCase):
+    def test_bounded_rolling_state_evicts_by_ttl_and_capacity(self):
+        from drf_api_logger.metrics.state import BoundedRollingState
+
+        state = BoundedRollingState(max_keys=2, ttl_seconds=10)
+
+        self.assertEqual(state.increment("a", now=100), 1)
+        self.assertEqual(state.increment("a", now=101), 2)
+        self.assertEqual(state.increment("b", now=102), 1)
+        self.assertEqual(state.increment("c", now=103), 1)
+        self.assertEqual(state.get("a", now=104), 0)
+        self.assertEqual(state.get("b", now=104), 1)
+        self.assertEqual(state.get("b", now=200), 0)
+
+
+class MetricsSystemCheckTests(TestCase):
+    @override_settings(
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="prometheus",
+    )
+    def test_metrics_enabled_without_prometheus_dependency_reports_error(self):
+        from drf_api_logger.metrics.system_checks import check_metrics_configuration
+
+        messages = check_metrics_configuration(None)
+
+        self.assertIn("drf_api_logger.E701", [message.id for message in messages])
+        self.assertIn(ERROR, [message.level for message in messages])
+
+    @override_settings(
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="none",
+        DRF_API_LOGGER_METRICS_LABELS=["method", "request_id"],
+        DRF_API_LOGGER_METRICS_PROMETHEUS_ENDPOINT_ENABLED=True,
+        DRF_API_LOGGER_SECURITY_METRICS_ENABLED=True,
+        DRF_API_LOGGER_SECURITY_BODY_INSPECTION={
+            "enabled": True,
+            "max_body_bytes": -1,
+            "inspect_request_body": True,
+            "inspect_response_body": False,
+        },
+    )
+    def test_unsafe_metrics_configuration_reports_checks(self):
+        from drf_api_logger.metrics.system_checks import check_metrics_configuration
+
+        messages = check_metrics_configuration(None)
+        ids = [message.id for message in messages]
+
+        self.assertIn("drf_api_logger.E702", ids)
+        self.assertIn("drf_api_logger.W703", ids)
+        self.assertIn("drf_api_logger.E704", ids)
+        self.assertIn(WARNING, [message.level for message in messages])
+
+    @override_settings(
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="prometheus",
+    )
+    @patch.dict("os.environ", {"WEB_CONCURRENCY": "4"}, clear=True)
+    def test_prometheus_multiprocess_configuration_reports_warning(self):
+        from drf_api_logger.metrics.system_checks import check_metrics_configuration
+
+        messages = check_metrics_configuration(None)
+
+        self.assertIn("drf_api_logger.W705", [message.id for message in messages])
+
+
+class MetricsMiddlewareTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def get_response(self, request):
+        return HttpResponse(
+            json.dumps({"message": "ok"}),
+            content_type="application/json",
+            status=200,
+        )
+
+    def throttled_response(self, request):
+        return HttpResponse(
+            json.dumps({"detail": "throttled"}),
+            content_type="application/json",
+            status=429,
+        )
+
+    def not_found_response(self, request):
+        return HttpResponse(
+            json.dumps({"detail": "missing"}),
+            content_type="application/json",
+            status=404,
+        )
+
+    def unauthorized_response(self, request):
+        return HttpResponse(
+            json.dumps({"detail": "unauthorized"}),
+            content_type="application/json",
+            status=401,
+        )
+
+    @override_settings(
+        DRF_API_LOGGER_DATABASE=False,
+        DRF_API_LOGGER_SIGNAL=False,
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="none",
+        DRF_API_LOGGER_API_METRICS_ENABLED=True,
+        DRF_API_LOGGER_ENABLE_CORRELATION=True,
+    )
+    @patch("drf_api_logger.middleware.api_logger_middleware.get_recorder")
+    @patch("drf_api_logger.middleware.api_logger_middleware.resolve")
+    def test_api_metrics_can_observe_without_database_or_signal_logging(
+        self,
+        mock_resolve,
+        mock_get_recorder,
+    ):
+        recorder = FakeRecorder()
+        mock_get_recorder.return_value = recorder
+        mock_resolve.return_value.namespace = None
+        mock_resolve.return_value.app_name = "tests"
+        mock_resolve.return_value.url_name = "test"
+        mock_resolve.return_value.route = "api/test/"
+        mock_resolve.return_value.func = self.get_response
+
+        middleware = APILoggerMiddleware(get_response=self.get_response)
+        request = self.factory.get("/api/test/?token=secret")
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        http_calls = [call for call in recorder.calls if call[0] == "observe_http_request"]
+        self.assertEqual(len(http_calls), 1)
+        event = http_calls[0][1]
+        self.assertEqual(event["method"], "GET")
+        self.assertEqual(event["status_code"], 200)
+        self.assertEqual(event["low_cardinality"]["route"], "api/test/")
+        self.assertEqual(event["low_cardinality"]["status_class"], "2xx")
+        self.assertNotIn("token=secret", str(event))
+
+    @override_settings(
+        DRF_API_LOGGER_DATABASE=False,
+        DRF_API_LOGGER_SIGNAL=False,
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="none",
+        DRF_API_LOGGER_API_METRICS_ENABLED=True,
+        DRF_API_LOGGER_SLOW_API_ABOVE=0,
+    )
+    @patch("drf_api_logger.middleware.api_logger_middleware.get_recorder")
+    @patch("drf_api_logger.middleware.api_logger_middleware.resolve")
+    def test_api_metrics_include_active_size_slow_and_throttle_signals(
+        self,
+        mock_resolve,
+        mock_get_recorder,
+    ):
+        recorder = FakeRecorder()
+        mock_get_recorder.return_value = recorder
+        mock_resolve.return_value.namespace = None
+        mock_resolve.return_value.app_name = "tests"
+        mock_resolve.return_value.url_name = "throttle"
+        mock_resolve.return_value.route = "api/throttle/"
+        mock_resolve.return_value.func = self.throttled_response
+
+        middleware = APILoggerMiddleware(get_response=self.throttled_response)
+        request = self.factory.post(
+            "/api/throttle/?token=secret",
+            data=json.dumps({"message": "hello"}),
+            content_type="application/json",
+        )
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 429)
+        self.assertTrue(any(call[0] == "increment_active_requests" for call in recorder.calls))
+        self.assertTrue(any(call[0] == "decrement_active_requests" for call in recorder.calls))
+        http_event = [call[1] for call in recorder.calls if call[0] == "observe_http_request"][0]
+        self.assertEqual(http_event["status_code"], 429)
+        self.assertEqual(http_event["low_cardinality"]["status_class"], "4xx")
+        self.assertGreater(http_event["request_body_size_bytes"], 0)
+        self.assertGreater(http_event["response_body_size_bytes"], 0)
+        self.assertTrue(http_event["is_slow"])
+        self.assertEqual(http_event["throttle_scope"], "unknown")
+        self.assertNotIn("token=secret", str(http_event))
+
+    @override_settings(
+        DRF_API_LOGGER_DATABASE=False,
+        DRF_API_LOGGER_SIGNAL=False,
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="none",
+        DRF_API_LOGGER_API_METRICS_ENABLED=True,
+    )
+    @patch("drf_api_logger.middleware.api_logger_middleware.get_recorder")
+    @patch("drf_api_logger.middleware.api_logger_middleware.resolve")
+    def test_api_metrics_record_exceptions_without_swallowing_them(
+        self,
+        mock_resolve,
+        mock_get_recorder,
+    ):
+        def raises(request):
+            raise ValueError("private detail")
+
+        recorder = FakeRecorder()
+        mock_get_recorder.return_value = recorder
+        mock_resolve.return_value.namespace = None
+        mock_resolve.return_value.app_name = "tests"
+        mock_resolve.return_value.url_name = "raises"
+        mock_resolve.return_value.route = "api/raises/"
+        mock_resolve.return_value.func = raises
+
+        middleware = APILoggerMiddleware(get_response=raises)
+        request = self.factory.get("/api/raises/")
+
+        with self.assertRaises(ValueError):
+            middleware(request)
+
+        exception_events = [call[1] for call in recorder.calls if call[0] == "increment_http_exception"]
+        self.assertEqual(len(exception_events), 1)
+        self.assertEqual(exception_events[0]["exception_class"], "ValueError")
+        self.assertEqual(exception_events[0]["low_cardinality"]["route"], "api/raises/")
+        self.assertEqual(exception_events[0]["low_cardinality"]["status_class"], "5xx")
+        self.assertNotIn("private detail", str(exception_events[0]))
+        self.assertTrue(any(call[0] == "decrement_active_requests" for call in recorder.calls))
+
+    @override_settings(
+        DRF_API_LOGGER_SIGNAL=True,
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="none",
+        DRF_API_LOGGER_SECURITY_METRICS_ENABLED=True,
+    )
+    @patch("drf_api_logger.middleware.api_logger_middleware.get_recorder")
+    @patch("drf_api_logger.middleware.api_logger_middleware.resolve")
+    def test_security_metrics_use_response_status_class_not_pre_response_unknown(
+        self,
+        mock_resolve,
+        mock_get_recorder,
+    ):
+        recorder = FakeRecorder()
+        mock_get_recorder.return_value = recorder
+        mock_resolve.return_value.namespace = None
+        mock_resolve.return_value.app_name = "tests"
+        mock_resolve.return_value.url_name = "unauthorized"
+        mock_resolve.return_value.route = "api/unauthorized/"
+        mock_resolve.return_value.func = self.unauthorized_response
+
+        middleware = APILoggerMiddleware(get_response=self.unauthorized_response)
+        request = self.factory.get("/api/unauthorized/")
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 401)
+        security_calls = [call for call in recorder.calls if call[0] == "observe_security_event"]
+        self.assertGreaterEqual(len(security_calls), 1)
+        self.assertTrue(all(call[1].status_class == "4xx" for call in security_calls))
+
+    @override_settings(
+        DRF_API_LOGGER_DATABASE=False,
+        DRF_API_LOGGER_SIGNAL=False,
+        DRF_API_LOGGER_ENABLE_PROFILING=True,
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="none",
+        DRF_API_LOGGER_METRICS_GROUPS=["profiling"],
+        DRF_API_LOGGER_API_METRICS_ENABLED=True,
+        DRF_API_LOGGER_SECURITY_METRICS_ENABLED=True,
+    )
+    @patch("drf_api_logger.middleware.api_logger_middleware.get_recorder")
+    @patch("drf_api_logger.middleware.api_logger_middleware.resolve")
+    def test_unresolved_routes_do_not_emit_unknown_route_or_view_labels(
+        self,
+        mock_resolve,
+        mock_get_recorder,
+    ):
+        recorder = FakeRecorder()
+        mock_get_recorder.return_value = recorder
+        mock_resolve.side_effect = Resolver404({"path": "/favicon.ico"})
+
+        middleware = APILoggerMiddleware(get_response=self.not_found_response)
+        request = self.factory.get("/favicon.ico")
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 404)
+
+        http_event = [call[1] for call in recorder.calls if call[0] == "observe_http_request"][0]
+        self.assertEqual(http_event["low_cardinality"]["route"], "unresolved")
+        self.assertEqual(http_event["low_cardinality"]["view_name"], "unresolved")
+        self.assertEqual(http_event["low_cardinality"]["status_class"], "4xx")
+
+        profiling_labels = [call[1] for call in recorder.calls if call[0] == "observe_profiling"][0]
+        self.assertEqual(profiling_labels["route"], "unresolved")
+        self.assertEqual(profiling_labels["view_name"], "unresolved")
+
+        detection_labels = [call[1] for call in recorder.calls if call[0] == "observe_security_detection"][0]
+        self.assertEqual(detection_labels["route"], "unresolved")
+
+        security_signals = [call[1] for call in recorder.calls if call[0] == "observe_security_event"]
+        self.assertTrue(security_signals)
+        self.assertTrue(all(signal.route == "unresolved" for signal in security_signals))
+
+    @override_settings(
+        DRF_API_LOGGER_SIGNAL=True,
+        DRF_API_LOGGER_ENABLE_PROFILING=True,
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="none",
+        DRF_API_LOGGER_METRICS_GROUPS=["profiling"],
+    )
+    @patch("drf_api_logger.middleware.api_logger_middleware.get_recorder")
+    @patch("drf_api_logger.middleware.api_logger_middleware.resolve")
+    def test_profiling_metrics_emit_when_profiling_data_exists(
+        self,
+        mock_resolve,
+        mock_get_recorder,
+    ):
+        recorder = FakeRecorder()
+        mock_get_recorder.return_value = recorder
+        mock_resolve.return_value.namespace = None
+        mock_resolve.return_value.app_name = "tests"
+        mock_resolve.return_value.url_name = "profiled"
+        mock_resolve.return_value.route = "api/profiled/"
+        mock_resolve.return_value.func = self.get_response
+
+        middleware = APILoggerMiddleware(get_response=self.get_response)
+        request = self.factory.get("/api/profiled/")
+        middleware(request)
+
+        profiling_calls = [call for call in recorder.calls if call[0] == "observe_profiling"]
+        self.assertEqual(len(profiling_calls), 1)
+        self.assertEqual(profiling_calls[0][1]["route"], "api/profiled/")
+        self.assertIn("view_and_serialization", profiling_calls[0][2])
+
+    @override_settings(
+        DRF_API_LOGGER_SIGNAL=True,
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="none",
+        DRF_API_LOGGER_SECURITY_METRICS_ENABLED=True,
+        DRF_API_LOGGER_SECURITY_BODY_INSPECTION={
+            "enabled": True,
+            "max_body_bytes": 64,
+            "inspect_request_body": True,
+            "inspect_response_body": False,
+        },
+    )
+    @patch("drf_api_logger.middleware.api_logger_middleware.get_recorder")
+    @patch("drf_api_logger.middleware.api_logger_middleware.resolve")
+    def test_security_detection_records_bounded_payload_signal(
+        self,
+        mock_resolve,
+        mock_get_recorder,
+    ):
+        recorder = FakeRecorder()
+        mock_get_recorder.return_value = recorder
+        mock_resolve.return_value.namespace = None
+        mock_resolve.return_value.app_name = "tests"
+        mock_resolve.return_value.url_name = "test"
+        mock_resolve.return_value.route = "api/test/"
+        mock_resolve.return_value.func = self.get_response
+
+        middleware = APILoggerMiddleware(get_response=self.get_response)
+        request = self.factory.post(
+            "/api/test/",
+            data=json.dumps({"search": "' OR 1=1 --", "password": "secret"}),
+            content_type="application/json",
+        )
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        security_calls = [call for call in recorder.calls if call[0] == "observe_security_event"]
+        self.assertGreaterEqual(len(security_calls), 1)
+        signal = security_calls[0][1]
+        self.assertEqual(signal.rule_id, "DRFSEC-006")
+        self.assertEqual(signal.category, "payload")
+        self.assertNotIn("secret", str(signal))
+        self.assertNotIn("' OR 1=1", str(signal))
+
+
+class BackgroundPipelineMetricsTests(TestCase):
+    def log_data(self):
+        return {
+            "api": "/api/test/",
+            "method": "GET",
+            "status_code": 200,
+            "headers": "{}",
+            "body": "",
+            "response": "{}",
+            "client_ip_address": "127.0.0.1",
+            "execution_time": 0.1,
+            "added_on": timezone.now(),
+        }
+
+    @override_settings(
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="none",
+    )
+    @patch("drf_api_logger.insert_log_into_database.get_recorder")
+    @patch("drf_api_logger.insert_log_into_database.APILogsModel")
+    def test_queue_enqueue_updates_pipeline_metrics(self, mock_model, mock_get_recorder):
+        from drf_api_logger.insert_log_into_database import InsertLogIntoDatabase
+
+        recorder = FakeRecorder()
+        mock_get_recorder.return_value = recorder
+        thread = InsertLogIntoDatabase()
+
+        thread.put_log_data(self.log_data())
+
+        self.assertIn(("increment_enqueued_logs", "database"), recorder.calls)
+        self.assertIn(("set_queue_depth", "database", 1), recorder.calls)
+        self.assertIn(("set_queue_capacity", "database", 50), recorder.calls)
+        self.assertTrue(any(call[0] == "set_queue_utilization" for call in recorder.calls))
+        self.assertTrue(any(call[0] == "observe_enqueue" for call in recorder.calls))
+
+    @override_settings(
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="none",
+    )
+    @patch("drf_api_logger.insert_log_into_database.get_recorder")
+    @patch("drf_api_logger.insert_log_into_database.APILogsModel")
+    def test_bulk_insert_updates_processed_and_flush_metrics(self, mock_model, mock_get_recorder):
+        from drf_api_logger.insert_log_into_database import InsertLogIntoDatabase
+
+        recorder = FakeRecorder()
+        mock_get_recorder.return_value = recorder
+        mock_manager = Mock()
+        mock_model.objects = mock_manager
+        mock_manager.using.return_value.bulk_create.return_value = None
+
+        thread = InsertLogIntoDatabase()
+        thread._insert_into_data_base([Mock(), Mock()])
+
+        self.assertIn(("increment_processed_logs", "database", 2), recorder.calls)
+        self.assertTrue(any(call[0] == "observe_flush" for call in recorder.calls))
+        self.assertTrue(any(call[0] == "observe_storage_write" for call in recorder.calls))
+
+
+class SecurityRuleTests(TestCase):
+    def setUp(self):
+        from drf_api_logger.metrics.rules import reset_security_rule_state_for_tests
+
+        reset_security_rule_state_for_tests()
+
+    def test_security_rules_are_detect_only_and_do_not_expose_payload_values(self):
+        from drf_api_logger.metrics.security import SecurityContext, evaluate_security_signals
+
+        context = SecurityContext(
+            request=None,
+            response=None,
+            exception=None,
+            route="api/login/",
+            method="POST",
+            status_code=401,
+            status_class="4xx",
+            request_body_sample=b'{"password": "secret", "q": "<script>alert(1)</script>"}',
+            response_body_sample=None,
+            actor_fingerprint="actor-hmac",
+            low_cardinality={"route": "api/login/", "status_class": "4xx"},
+            business_context={},
+        )
+
+        signals = evaluate_security_signals(context)
+
+        self.assertTrue(any(signal.rule_id == "DRFSEC-001" for signal in signals))
+        self.assertTrue(any(signal.rule_id == "DRFSEC-006" for signal in signals))
+        self.assertTrue(all(signal.outcome == "observed" for signal in signals))
+        self.assertNotIn("secret", str(signals))
+        self.assertNotIn("<script>", str(signals))
+
+    @override_settings(
+        DRF_API_LOGGER_SECURITY_RULES={
+            "auth_abuse": True,
+            "token_abuse": True,
+            "route_scan": True,
+            "admin_probe": True,
+            "object_id_enumeration": True,
+            "payload_attack_patterns": True,
+            "resource_abuse": True,
+            "data_exfiltration": True,
+            "business_logic_hooks": True,
+        }
+    )
+    def test_security_registry_emits_all_rule_ids_with_bounded_state(self):
+        from drf_api_logger.metrics.security import SecurityContext, evaluate_security_signals
+
+        def context(**overrides):
+            request = Mock()
+            request.path = overrides.pop("path", "/api/orders/123/")
+            request.GET = overrides.pop("query", {})
+            values = {
+                "request": request,
+                "response": None,
+                "exception": None,
+                "route": "api/orders/<int:pk>/",
+                "method": "GET",
+                "status_code": 200,
+                "status_class": "2xx",
+                "request_body_sample": None,
+                "response_body_sample": None,
+                "actor_fingerprint": "actor-hmac",
+                "low_cardinality": {"route": "api/orders/<int:pk>/", "status_class": "2xx"},
+                "business_context": {},
+            }
+            values.update(overrides)
+            return SecurityContext(**values)
+
+        signals = []
+        signals += evaluate_security_signals(context(route="api/login/", method="POST", status_code=401, status_class="4xx"))
+        signals += evaluate_security_signals(context(route="api/login/", method="POST", status_code=401, status_class="4xx"))
+        signals += evaluate_security_signals(context(route="api/login/", method="POST", status_code=401, status_class="4xx"))
+        signals += evaluate_security_signals(context(route="api/login/", method="POST", status_code=200, status_class="2xx"))
+        signals += evaluate_security_signals(context(route="api/token/", method="POST", status_code=401, status_class="4xx"))
+        signals += evaluate_security_signals(context(route="api/private/", status_code=403, status_class="4xx"))
+        signals += evaluate_security_signals(context(route="admin/login/", path="/admin/login/", status_code=404, status_class="4xx"))
+        signals += evaluate_security_signals(context(request_body_sample=b"<script>alert(1)</script>"))
+        signals += evaluate_security_signals(context(status_code=429, status_class="4xx"))
+        signals += evaluate_security_signals(context(status_code=404, status_class="4xx", path="/api/missing-a/"))
+        signals += evaluate_security_signals(context(status_code=404, status_class="4xx", path="/api/missing-b/"))
+        signals += evaluate_security_signals(context(status_code=404, status_class="4xx", path="/api/missing-c/"))
+        signals += evaluate_security_signals(context(status_code=404, status_class="4xx", path="/api/orders/1/"))
+        signals += evaluate_security_signals(context(status_code=404, status_class="4xx", path="/api/orders/2/"))
+        signals += evaluate_security_signals(context(status_code=404, status_class="4xx", path="/api/orders/3/"))
+        signals += evaluate_security_signals(context(request_body_sample=b"hello\nworld"))
+        signals += evaluate_security_signals(context(response_body_sample=b'{"api_key": "secret"}'))
+        signals += evaluate_security_signals(context(query={"page": "1"}))
+        signals += evaluate_security_signals(context(query={"page": "2"}))
+        signals += evaluate_security_signals(context(query={"page": "3"}))
+        signals += evaluate_security_signals(context(route="api/export/", response_body_sample=b"x" * 8192))
+        signals += evaluate_security_signals(context(response_body_sample=b"x" * 8192))
+        signals += evaluate_security_signals(
+            context(
+                business_context={
+                    "is_sensitive_route": True,
+                    "flow_name": "checkout",
+                    "business_action": "payment_attempted",
+                }
+            )
+        )
+        signals += evaluate_security_signals(
+            context(
+                business_context={
+                    "flow_name": "checkout",
+                    "business_action": "payment_attempted",
+                }
+            )
+        )
+        signals += evaluate_security_signals(
+            context(
+                business_context={
+                    "flow_name": "checkout",
+                    "business_action": "payment_attempted",
+                }
+            )
+        )
+
+        rule_ids = {signal.rule_id for signal in signals}
+        self.assertEqual(rule_ids, {"DRFSEC-%03d" % index for index in range(1, 17)})
+        self.assertNotIn("secret", str(signals))
+
+
+class MetricsEndpointTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @override_settings(DRF_API_LOGGER_METRICS_PROMETHEUS_ENDPOINT_ENABLED=False)
+    def test_metrics_endpoint_is_disabled_by_default(self):
+        from drf_api_logger.metrics.views import prometheus_metrics_view
+
+        with self.assertRaises(Http404):
+            prometheus_metrics_view(self.factory.get("/metrics/"))
+
+    @override_settings(
+        DRF_API_LOGGER_METRICS_ENABLED=True,
+        DRF_API_LOGGER_METRICS_EXPORTER="prometheus",
+        DRF_API_LOGGER_METRICS_PROMETHEUS_ENDPOINT_ENABLED=True,
+    )
+    @patch("drf_api_logger.metrics.views.generate_prometheus_latest", return_value=b"# HELP test\n")
+    def test_metrics_endpoint_returns_prometheus_text_when_enabled(self, mock_generate):
+        from drf_api_logger.metrics.views import prometheus_metrics_view
+
+        response = prometheus_metrics_view(self.factory.get("/metrics/"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/plain", response["Content-Type"])
+        self.assertEqual(response.content, b"# HELP test\n")


### PR DESCRIPTION
## Summary
- Add optional first-party Prometheus metrics for logger health, pipeline behavior, API timing, profiling, and detect-only security signals.
- Keep metric labels low-cardinality, including fixed unresolved-route labels instead of raw 404 paths or `unknown` status labels.
- Document practical metric advantages with dashboard/alert examples and bump package metadata to `1.4.0`.

## Verification
- `coverage run --source=drf_api_logger -m django test tests --settings=tests.test_settings --verbosity=1` - 307 tests passed.
- `coverage report` - total coverage 89%.
- `python -m sphinx -b html docs docs/_build/html` - build succeeded.
- `python -m build --sdist --wheel` - built `drf_api_logger-1.4.0.tar.gz` and `drf_api_logger-1.4.0-py3-none-any.whl`.
- `python -m twine check dist/*` - both artifacts passed.
- `git diff --cached --check` - passed.